### PR TITLE
[POC][C] Use useRouter and NamedLink to determine if a path is active

### DIFF
--- a/components/atomic/links/NamedLink/NamedLink.tsx
+++ b/components/atomic/links/NamedLink/NamedLink.tsx
@@ -1,5 +1,6 @@
 import React, { forwardRef } from "react";
 import Link from "next/link";
+import isFunction from "lodash/isFunction";
 import { routes } from "helpers";
 type LinkProps = React.ComponentProps<typeof Link>;
 
@@ -10,11 +11,15 @@ const NamedLink = forwardRef(
   ({ route, routeParams, query, children, passHref, ...props }: Props, ref) => {
     // If the route can't be found, fallback to the original value
     const pathname = routes[route] ? routes[route](routeParams) : route;
+    // We could check if the pathname is active here,
+    // but not all NamedLinks need to know if the route is currently active
 
     // Pass all other props to Link
     return (
       <Link href={{ pathname, query }} passHref={passHref} {...props}>
-        {React.isValidElement(children)
+        {isFunction(children)
+          ? children({ ...props, pathname, query })
+          : React.isValidElement(children)
           ? React.cloneElement(children, { ref, ...props })
           : children}
       </Link>

--- a/components/auth/Authorize/Authorize.tsx
+++ b/components/auth/Authorize/Authorize.tsx
@@ -19,6 +19,6 @@ export default function Authorize({
 
 interface Props {
   children: JSX.Element;
-  actions: string | string[] | null;
+  actions: string | string[];
   allowedActions?: string[] | readonly string[];
 }

--- a/components/composed/model/ModelHeader/ModelHeader.tsx
+++ b/components/composed/model/ModelHeader/ModelHeader.tsx
@@ -1,59 +1,40 @@
 import React from "react";
-import Link from "next/link";
 import { PageHeader } from "components/layout";
-import { TabNav } from "components/atomic";
-
+import { NamedLink, TabNav } from "components/atomic";
 import { BreadcrumbListType } from "hooks/useBreadcrumbs";
-import { modelMap } from "helpers/routes";
+import { useRouter } from "next/router";
 
 /**
  * Takes an model id, object, and current router view,
  * and returns a PageHeader with the model title, breadcrumbs, and tabbed navigation.
  */
-const ModelHeader = ({ type, id, title, view, breadcrumbs }: Props) => {
+const ModelHeader = ({ model, id, title, breadcrumbs }: Props) => {
+  const router = useRouter();
   // TODO: Refactor this once we arrive at a sustainable routing approach.
   function getTabs() {
-    const tabs = [
-      <Link key="manage" href={`/${modelMap[type]}/${id}/manage`} passHref>
-        <TabNav.Tab active={view === "manage"}>Manage</TabNav.Tab>
-      </Link>,
-    ];
+    const getTab = (route: string, label: string) => (
+      <NamedLink key="manage" route={route} routeParams={{ id }} passHref>
+        {({ pathname }: { pathname: string }) => (
+          <TabNav.Tab active={pathname === router.asPath}>{label}</TabNav.Tab>
+        )}
+      </NamedLink>
+    );
 
-    if (!["COMMUNITY", "CONTRIBUTOR"].includes(type)) {
-      tabs.unshift(
-        <Link key="items" href={`/${modelMap[type]}/${id}/items`} passHref>
-          <TabNav.Tab active={view === "items"}>Child Items</TabNav.Tab>
-        </Link>
-      );
+    const tabs = [];
+
+    if (["community", "collection"].includes(model)) {
+      tabs.push(getTab(`${model}Collections`, "Child Collections"));
     }
 
-    if (["CONTRIBUTOR"].includes(type)) {
-      tabs.unshift(
-        <Link
-          key="contributions"
-          href={`/${modelMap[type]}/${id}/contributions`}
-          passHref
-        >
-          <TabNav.Tab active={view === "contributions"}>
-            Contributions
-          </TabNav.Tab>
-        </Link>
-      );
+    if (["community", "collection", "item"].includes(model)) {
+      tabs.push(getTab(`${model}Items`, "Child Items"));
     }
 
-    if (!["ITEM", "CONTRIBUTOR"].includes(type)) {
-      tabs.unshift(
-        <Link
-          key="collections"
-          href={`/${modelMap[type]}/${id}/collections`}
-          passHref
-        >
-          <TabNav.Tab active={view === "collections"}>
-            Child Collections
-          </TabNav.Tab>
-        </Link>
-      );
+    if (["contributor"].includes(model)) {
+      tabs.push(getTab(`${model}Contributions`, "Contributions"));
     }
+
+    tabs.push(getTab(`${model}Manage`, "Manage"));
 
     return tabs;
   }
@@ -65,14 +46,13 @@ const ModelHeader = ({ type, id, title, view, breadcrumbs }: Props) => {
   );
 };
 
-type HeaderTypes = "COMMUNITY" | "COLLECTION" | "ITEM" | "USER" | "CONTRIBUTOR";
+type ModelTypes = "community" | "collection" | "item" | "user" | "contributor";
 
 interface Props {
-  type: HeaderTypes;
+  model: ModelTypes;
   id: string;
   title: string;
   breadcrumbs?: BreadcrumbListType;
-  view?: string;
 }
 
 export default ModelHeader;

--- a/components/global/Header/HeaderNavLinks.tsx
+++ b/components/global/Header/HeaderNavLinks.tsx
@@ -1,42 +1,71 @@
 import React from "react";
-import { useGetActiveModel } from "hooks/useRouterContext";
 import { Dropdown, NamedLink } from "components/atomic";
 import { Authorize } from "components/auth";
 import * as Styled from "./Header.styles";
 import { useTranslation } from "react-i18next";
+import { useRouter } from "next/router";
 
-const HeaderNavLinks = ({ navigation }) => {
+const HeaderNavLinks = ({ navigation }: Props) => {
   const { t } = useTranslation("common");
-  const activeModel = useGetActiveModel();
+  const { asPath } = useRouter();
+  // Alternatively, you could try matching path with a path set on each nav child:
+  // child: { path: '/communities' } === router: { path: '/communities' }
+  // or reference the child's model
+  // child: { model: 'communities' } === router.query.model;
 
-  const renderLink = (child) => (
-    <NamedLink route={child.route} passHref>
-      <Styled.Link active={activeModel === child.model}>
-        {t(child.label)}
-      </Styled.Link>
-    </NamedLink>
-  );
+  // Get the pathname from NamedLink, check if it's currently active
+  const renderLink = (child: ChildLink) => {
+    if (!child.route) return <></>;
 
-  return navigation.map((child, i) =>
-    child.children ? (
-      <Authorize actions={child.actions} key={i}>
-        <Styled.Item>
-          <Dropdown
-            label={t(child.label)}
-            disclosure={<Styled.Link as="button">{t(child.label)}</Styled.Link>}
-            menuItems={child.children.map(renderLink)}
-            isDarkMode
-          />
-        </Styled.Item>
-      </Authorize>
-    ) : child.actions ? (
-      <Authorize actions={child.actions} key={i}>
-        <Styled.Item>{renderLink(child)}</Styled.Item>
-      </Authorize>
-    ) : (
-      <Styled.Item key={i}>{renderLink(child)}</Styled.Item>
-    )
+    return (
+      <NamedLink route={child.route} passHref>
+        {({ pathname }: { pathname: string }) => (
+          <Styled.Link active={asPath.indexOf(pathname) === 0}>
+            {t(child.label)}
+          </Styled.Link>
+        )}
+      </NamedLink>
+    );
+  };
+
+  return (
+    <>
+      {navigation.map((child, i: number) =>
+        child.children && child.actions ? (
+          <Authorize actions={child.actions} key={i}>
+            <Styled.Item>
+              <Dropdown
+                label={t(child.label)}
+                disclosure={
+                  <Styled.Link as="button">{t(child.label)}</Styled.Link>
+                }
+                menuItems={child.children.map(renderLink)}
+                isDarkMode
+              />
+            </Styled.Item>
+          </Authorize>
+        ) : child.actions ? (
+          <Authorize actions={child.actions} key={i}>
+            <Styled.Item>{renderLink(child)}</Styled.Item>
+          </Authorize>
+        ) : (
+          <Styled.Item key={i}>{renderLink(child)}</Styled.Item>
+        )
+      )}
+    </>
   );
 };
+
+interface ChildLink {
+  label: string;
+  route?: string;
+  model?: string;
+  actions?: string | string[];
+  children?: Omit<ChildLink, "children">[];
+}
+
+interface Props {
+  navigation: ChildLink[];
+}
 
 export default HeaderNavLinks;

--- a/components/layout/Table/Table.styles.ts
+++ b/components/layout/Table/Table.styles.ts
@@ -106,6 +106,7 @@ export const HeaderCellInner = styled.span`
 export const Cell = styled.td`
   padding-block: ${basePadding(2)};
   padding-inline-end: var(--table-column-gap);
+  height: ${basePadding(12)};
 
   ${({ align }) =>
     align &&

--- a/components/views/collections/CollectionDetail.tsx
+++ b/components/views/collections/CollectionDetail.tsx
@@ -56,8 +56,7 @@ export default function CollectionDetail() {
       {data && data.collection && (
         <ModelHeader
           id={id}
-          type="COLLECTION"
-          view={view}
+          model="collection"
           title={data.collection.title}
           breadcrumbs={breadcrumbs}
         />

--- a/components/views/communities/CommunityDetail.tsx
+++ b/components/views/communities/CommunityDetail.tsx
@@ -50,12 +50,7 @@ export default function CommunityDetail() {
   return (
     <section>
       {data && data.community && (
-        <ModelHeader
-          id={id}
-          title={data.community.name}
-          view={view}
-          type="COMMUNITY"
-        />
+        <ModelHeader id={id} title={data.community.name} model="community" />
       )}
 
       {view === "main" && <div>Main</div>}

--- a/components/views/contributors/ContributorDetail.tsx
+++ b/components/views/contributors/ContributorDetail.tsx
@@ -44,8 +44,7 @@ export default function ContributorDetail() {
             data?.contributor?.name ||
             `${data?.contributor?.firstName} ${data?.contributor?.lastName}`
           }`}
-          view={view}
-          type="CONTRIBUTOR"
+          model="contributor"
         />
       )}
 

--- a/components/views/items/ItemDetail.tsx
+++ b/components/views/items/ItemDetail.tsx
@@ -55,8 +55,7 @@ export default function ItemDetail() {
       {item && (
         <ModelHeader
           id={id}
-          type="ITEM"
-          view={view}
+          model="item"
           title={item.title}
           breadcrumbs={breadcrumbs}
         />

--- a/helpers/routes.ts
+++ b/helpers/routes.ts
@@ -24,14 +24,31 @@ export const modelMap = {
 export const routes: RoutesMap = {
   communityList: (): string => `/communities`,
   communityDetail: (params?: Params): string => `/communities/${params?.id}`,
+  communityManage: (params?: Params): string =>
+    `/communities/${params?.id}/manage`,
+  communityCollections: (params?: Params): string =>
+    `/communities/${params?.id}/collections`,
   collectionList: (): string => `/collections`,
   collectionDetail: (params?: Params): string => `/collections/${params?.id}`,
+  collectionManage: (params?: Params): string =>
+    `/collections/${params?.id}/manage`,
+  collectionCollections: (params?: Params): string =>
+    `/collections/${params?.id}/collections`,
+  collectionItems: (params?: Params): string =>
+    `/collections/${params?.id}/items`,
   itemList: (): string => `/items`,
   itemDetail: (params?: Params): string => `/items/${params?.id}`,
+  itemManage: (params?: Params): string => `/items/${params?.id}/manage`,
+  itemItems: (params?: Params): string => `/items/${params?.id}/items`,
   userList: (): string => `/users`,
   userDetail: (params?: Params): string => `/users/${params?.id}`,
+  userManage: (params?: Params): string => `/users/${params?.id}/manage`,
   contributorList: (): string => `/contributors`,
   contributorDetail: (params?: Params): string => `/contributors/${params?.id}`,
+  contributorManage: (params?: Params): string =>
+    `/contributors/${params?.id}/manage`,
+  contributorContributions: (params?: Params): string =>
+    `/contributors/${params?.id}/contributions`,
 };
 
 // Gets the current asPath from useRouter

--- a/hooks/useIsAuthorized.ts
+++ b/hooks/useIsAuthorized.ts
@@ -24,7 +24,7 @@ export const useIsAuthorized = ({
 };
 
 export interface useIsAuthorizedProps {
-  actions: string[] | string | null;
+  actions: string[] | string;
   allowedActions?: string[] | readonly string[];
 }
 


### PR DESCRIPTION
This is a POC for determining if a route is active in the header and tab navigation (and potentially elsewhere in the app).

This _does not_ fix the current problem with routing, but it does give us an example solution for checking if links are currently active. This POC assumes that:
1. We're sticking with `next/router`
2. We will have a master list of routes or some way to get the final pathname from `NamedLink`

I added the missing routes to `helpers/routes`, and an option to render a NamedLink's child with a function. Example:
```
const { asPath } = useRouter();
...
<NamedLink route="collectionManage" routeParams={{ id }} passHref>
    {({ pathname }: { pathname: string }) => (
        <TabNav.Tab active={pathname === asPath}>Manage</TabNav.Tab>
    )}
</NamedLink>
```

NamedLink returns the route's pathname, ie `collections/<id>/manage` in the above example. We can check this pathname against the current `asPath` value in router to see if it's currently active. If we need to, we can use the pathname to check for a partial match. 

Again, this isn't a major reconstruction of routing, it's just a small example of checking against the current path. We only do this in the Header and the TabNav, so it didn't seem necessary to apply that logic to all instances of `NamedLink`. On the plus side, `components/composed/model/ModelHeader/ModelHeader.tsx` is a lot DRYer than it was, and I can see a lot more areas which could be cleaned up while still using `next/router`. I've decided to stop here in order to keep the PR small and focused.