### PR TITLE
[B] Fix inconsistent collection slug redirects

### DIFF
--- a/__generated__/CollectionSlugRedirectFragment.graphql.ts
+++ b/__generated__/CollectionSlugRedirectFragment.graphql.ts
@@ -1,0 +1,71 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+import { FragmentRefs } from "relay-runtime";
+export type CollectionSlugRedirectFragment = {
+    readonly slug: string;
+    readonly collections: {
+        readonly pageInfo: {
+            readonly totalCount: number;
+        };
+    };
+    readonly " $refType": "CollectionSlugRedirectFragment";
+};
+export type CollectionSlugRedirectFragment$data = CollectionSlugRedirectFragment;
+export type CollectionSlugRedirectFragment$key = {
+    readonly " $data"?: CollectionSlugRedirectFragment$data;
+    readonly " $fragmentRefs": FragmentRefs<"CollectionSlugRedirectFragment">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "CollectionSlugRedirectFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slug",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "CollectionConnection",
+      "kind": "LinkedField",
+      "name": "collections",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "kind": "LinkedField",
+          "name": "pageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "totalCount",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Collection",
+  "abstractKey": null
+};
+(node as any).hash = 'f44f48ecf10416dfab932ef7c95ce369';
+export default node;

--- a/__generated__/SlugCollectionsPageQuery.graphql.ts
+++ b/__generated__/SlugCollectionsPageQuery.graphql.ts
@@ -9,12 +9,7 @@ export type SlugCollectionsPageQueryVariables = {
 };
 export type SlugCollectionsPageQueryResponse = {
     readonly collection: {
-        readonly collections: {
-            readonly pageInfo: {
-                readonly totalCount: number;
-            };
-        };
-        readonly " $fragmentRefs": FragmentRefs<"CollectionLayoutQueryFragment">;
+        readonly " $fragmentRefs": FragmentRefs<"CollectionLayoutQueryFragment" | "CollectionSlugRedirectFragment">;
     } | null;
 };
 export type SlugCollectionsPageQuery = {
@@ -30,11 +25,7 @@ query SlugCollectionsPageQuery(
 ) {
   collection(slug: $collectionSlug) {
     ...CollectionLayoutQueryFragment
-    collections {
-      pageInfo {
-        totalCount
-      }
-    }
+    ...CollectionSlugRedirectFragment
     id
   }
 }
@@ -47,6 +38,15 @@ fragment CollectionLayoutFragment on Collection {
 
 fragment CollectionLayoutQueryFragment on Collection {
   ...CollectionLayoutFragment
+}
+
+fragment CollectionSlugRedirectFragment on Collection {
+  slug
+  collections {
+    pageInfo {
+      totalCount
+    }
+  }
 }
 
 fragment useBreadcrumbsFragment on Entity {
@@ -79,40 +79,11 @@ v1 = [
 v2 = {
   "alias": null,
   "args": null,
-  "concreteType": "CollectionConnection",
-  "kind": "LinkedField",
-  "name": "collections",
-  "plural": false,
-  "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "PageInfo",
-      "kind": "LinkedField",
-      "name": "pageInfo",
-      "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "totalCount",
-          "storageKey": null
-        }
-      ],
-      "storageKey": null
-    }
-  ],
-  "storageKey": null
-},
-v3 = {
-  "alias": null,
-  "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v4 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -134,11 +105,15 @@ return {
         "name": "collection",
         "plural": false,
         "selections": [
-          (v2/*: any*/),
           {
             "args": null,
             "kind": "FragmentSpread",
             "name": "CollectionLayoutQueryFragment"
+          },
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "CollectionSlugRedirectFragment"
           }
         ],
         "storageKey": null
@@ -168,9 +143,37 @@ return {
             "name": "title",
             "storageKey": null
           },
-          (v3/*: any*/),
           (v2/*: any*/),
-          (v4/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "CollectionConnection",
+            "kind": "LinkedField",
+            "name": "collections",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "kind": "LinkedField",
+                "name": "pageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "totalCount",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          (v3/*: any*/),
           {
             "kind": "InlineFragment",
             "selections": [
@@ -203,8 +206,8 @@ return {
                     "name": "kind",
                     "storageKey": null
                   },
-                  (v3/*: any*/),
-                  (v4/*: any*/)
+                  (v2/*: any*/),
+                  (v3/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -218,14 +221,14 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f7e832f1c599c18ab4c9afe36007b521",
+    "cacheID": "dc0f1a359a3cc174f469ae4709321d72",
     "id": null,
     "metadata": {},
     "name": "SlugCollectionsPageQuery",
     "operationKind": "query",
-    "text": "query SlugCollectionsPageQuery(\n  $collectionSlug: Slug!\n) {\n  collection(slug: $collectionSlug) {\n    ...CollectionLayoutQueryFragment\n    collections {\n      pageInfo {\n        totalCount\n      }\n    }\n    id\n  }\n}\n\nfragment CollectionLayoutFragment on Collection {\n  title\n  slug\n  ...useBreadcrumbsFragment\n}\n\nfragment CollectionLayoutQueryFragment on Collection {\n  ...CollectionLayoutFragment\n}\n\nfragment useBreadcrumbsFragment on Entity {\n  __isEntity: __typename\n  breadcrumbs {\n    depth\n    label\n    kind\n    slug\n    id\n  }\n}\n"
+    "text": "query SlugCollectionsPageQuery(\n  $collectionSlug: Slug!\n) {\n  collection(slug: $collectionSlug) {\n    ...CollectionLayoutQueryFragment\n    ...CollectionSlugRedirectFragment\n    id\n  }\n}\n\nfragment CollectionLayoutFragment on Collection {\n  title\n  slug\n  ...useBreadcrumbsFragment\n}\n\nfragment CollectionLayoutQueryFragment on Collection {\n  ...CollectionLayoutFragment\n}\n\nfragment CollectionSlugRedirectFragment on Collection {\n  slug\n  collections {\n    pageInfo {\n      totalCount\n    }\n  }\n}\n\nfragment useBreadcrumbsFragment on Entity {\n  __isEntity: __typename\n  breadcrumbs {\n    depth\n    label\n    kind\n    slug\n    id\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '230cb03deb2b1369938d308ce7f2badc';
+(node as any).hash = 'b9287cef6d9ecada81b655f075721888';
 export default node;

--- a/components/composed/collection/CollectionSlugRedirect/CollectionSlugRedirect.tsx
+++ b/components/composed/collection/CollectionSlugRedirect/CollectionSlugRedirect.tsx
@@ -1,0 +1,60 @@
+import React, { useCallback, useEffect } from "react";
+import { useMaybeFragment, useRouteSlug } from "hooks";
+import { graphql } from "react-relay";
+import { LoadingCircle } from "components/atomic";
+import { useRouter } from "next/router";
+import { RouteHelper } from "routes";
+import { CollectionSlugRedirectFragment$key } from "@/relay/CollectionSlugRedirectFragment.graphql";
+
+function CollectionSlugRedirect({ data }: Props) {
+  const slug = useRouteSlug();
+  const router = useRouter();
+
+  const collection = useMaybeFragment<CollectionSlugRedirectFragment$key>(
+    fragment,
+    data
+  );
+
+  const redirect = useCallback(
+    (slug: string, routeName: string) => {
+      const newRoute = RouteHelper.findRouteByName(routeName);
+
+      router.replace({
+        pathname: newRoute?.path,
+        query: { slug },
+      });
+    },
+    [router]
+  );
+
+  useEffect(() => {
+    // Check if we're getting cached data by comparing slugs
+    if (!collection || collection?.slug !== slug) return;
+    const total = collection?.collections?.pageInfo?.totalCount;
+
+    if (total === 0) {
+      redirect(slug, "collection.child.items");
+    } else {
+      redirect(slug, "collection.child.collections");
+    }
+  }, [collection, slug, redirect]);
+
+  return <LoadingCircle />;
+}
+
+interface Props {
+  data?: CollectionSlugRedirectFragment$key | null;
+}
+
+const fragment = graphql`
+  fragment CollectionSlugRedirectFragment on Collection {
+    slug
+    collections {
+      pageInfo {
+        totalCount
+      }
+    }
+  }
+`;
+
+export default CollectionSlugRedirect;

--- a/components/composed/collection/CollectionSlugRedirect/index.ts
+++ b/components/composed/collection/CollectionSlugRedirect/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CollectionSlugRedirect";

--- a/pages/collections/[slug]/index.tsx
+++ b/pages/collections/[slug]/index.tsx
@@ -1,42 +1,20 @@
+import React from "react";
 import { graphql } from "react-relay";
-import { useRouteSlug } from "hooks";
 import { SlugCollectionsPageQuery as Query } from "@/relay/SlugCollectionsPageQuery.graphql";
 import { GetLayout } from "types/page";
-import { useRouter } from "next/router";
 import CollectionLayoutQuery from "components/composed/collection/CollectionLayoutQuery";
-import { RouteHelper } from "routes";
-import { LoadingCircle } from "components/atomic";
+import CollectionSlugRedirect from "components/composed/collection/CollectionSlugRedirect";
 
-const getLayout: GetLayout<Props> = (props) => {
-  return <CollectionLayoutQuery<Query, Props> query={query} {...props} />;
-};
 function CollectionSlug({ data }: Props) {
-  const slug = useRouteSlug();
-  const router = useRouter();
-  const collectionRoute = RouteHelper.findRouteByName(
-    "collection.child.collections"
-  );
-  const itemRoute = RouteHelper.findRouteByName("collection.child.items");
-
-  const total = data?.collection?.collections?.pageInfo?.totalCount;
-
-  if (total && total > 0 && collectionRoute) {
-    router.replace({
-      pathname: collectionRoute.path,
-      query: { slug },
-    });
-  } else if (total === 0 && itemRoute) {
-    router.replace({
-      pathname: itemRoute.path,
-      query: { slug },
-    });
-  }
-
-  return <LoadingCircle />;
+  return <CollectionSlugRedirect data={data?.collection} />;
 }
 
 type Props = {
   data: Query["response"];
+};
+
+const getLayout: GetLayout<Props> = (props) => {
+  return <CollectionLayoutQuery<Query, Props> query={query} {...props} />;
 };
 
 CollectionSlug.getLayout = getLayout;
@@ -47,11 +25,7 @@ const query = graphql`
   query SlugCollectionsPageQuery($collectionSlug: Slug!) {
     collection(slug: $collectionSlug) {
       ...CollectionLayoutQueryFragment
-      collections {
-        pageInfo {
-          totalCount
-        }
-      }
+      ...CollectionSlugRedirectFragment
     }
   }
 `;


### PR DESCRIPTION
The problem:
1. The back button stopped working after redirect
2. The cached query returned on `collections/slug` was for the previous collection, and had the wrong total

This checks the slug from the cached response against the new slug, and only redirects if the slugs match and the total of collections equals 0.