### PR TITLE
[B] Fix entity radio group

### DIFF
--- a/packages/admin/components/composed/ordering/EntityOrderingAddForm/EntityOrderingAddForm.tsx
+++ b/packages/admin/components/composed/ordering/EntityOrderingAddForm/EntityOrderingAddForm.tsx
@@ -1,13 +1,12 @@
 import * as React from "react";
 import { graphql, useFragment } from "react-relay";
-import { useTranslation } from "react-i18next";
+import { useUID } from "react-uid";
 import MutationForm, {
   useRenderForm,
   useToVariables,
   Forms,
 } from "components/api/MutationForm";
 import { convertToSlug } from "helpers";
-import { useUID } from "react-uid";
 
 import type {
   EntityOrderingAddFormMutation,
@@ -81,6 +80,7 @@ export default function EntityOrderingAddForm({
           name: data.name,
           identifier: `${convertToSlug(data?.name ?? undefined)}-${uid}`,
           order: getOrder(data.sortby),
+          select: { direct: data.selectDirect },
         },
       };
     },
@@ -88,55 +88,52 @@ export default function EntityOrderingAddForm({
   );
 
   const defaultValues = {
-    select: { direct: "CHILDREN" },
+    // Flatten select object into separate fields
+    selectDirect: "CHILDREN",
     entityId: undefined,
     identifier: undefined,
     order: { path: undefined, direction: undefined },
   };
 
-  const renderForm = useRenderForm<Fields>(
-    ({ form: { register, getValues } }) => {
-      console.log(getValues());
-      return (
-        <Forms.Grid>
-          <Forms.Input
-            label={"forms.fields.displayname"}
-            required
-            {...register("name")}
-          />
-          <Forms.Select
-            label="forms.fields.sortby"
-            options={[
-              { value: "name, asc", label: "Name, ascending" },
-              { value: "name, desc", label: "Name, descending" },
-              { value: "updatedAt, asc", label: "Updated at, ascending" },
-              { value: "updatedAt, desc", label: "Updated at, descending" },
-              {
-                value: "published, asc",
-                label: "Publication date, ascending",
-              },
-              {
-                value: "published, desc",
-                label: "Publication date, descending",
-              },
-            ]}
-            {...register("sortby")}
-          />
-          <Forms.RadioGroup
-            label="forms.fields.include"
-            description={description}
-            {...register("select.direct")}
-            options={[
-              { value: "NONE", label: "None" },
-              { value: "CHILDREN", label: "Direct Descendants", default: true },
-              { value: "DESCENDANTS", label: "All Descendants" },
-            ]}
-          />
-        </Forms.Grid>
-      );
-    },
-    []
-  );
+  const renderForm = useRenderForm<Fields>(({ form: { register, watch } }) => {
+    console.log(watch("selectDirect"));
+    return (
+      <Forms.Grid>
+        <Forms.Input
+          label={"forms.fields.displayname"}
+          required
+          {...register("name")}
+        />
+        <Forms.Select
+          label="forms.fields.sortby"
+          options={[
+            { value: "name, asc", label: "Name, ascending" },
+            { value: "name, desc", label: "Name, descending" },
+            { value: "updatedAt, asc", label: "Updated at, ascending" },
+            { value: "updatedAt, desc", label: "Updated at, descending" },
+            {
+              value: "published, asc",
+              label: "Publication date, ascending",
+            },
+            {
+              value: "published, desc",
+              label: "Publication date, descending",
+            },
+          ]}
+          {...register("sortby")}
+        />
+        <Forms.RadioGroup
+          label="forms.fields.include"
+          description={description}
+          options={[
+            { value: "CHILDREN", label: "Direct Descendants" },
+            { value: "DESCENDANTS", label: "All Descendants" },
+          ]}
+          {...register("selectDirect")}
+        />
+      </Forms.Grid>
+    );
+  }, []);
 
   return (
     <MutationForm<EntityOrderingAddFormMutation, Fields>
@@ -160,10 +157,11 @@ type Props = Pick<
   "onSuccess" | "onCancel"
 > & { data: EntityOrderingAddFormFragment$key };
 
-type Fields = Omit<CreateOrderingInput, "clientMutationId"> &
+type Fields = Omit<CreateOrderingInput, "clientMutationId" | "select"> &
   OrderDefinitionInput &
   OrderingSelectDefinitionInput & {
     sortby: string;
+    selectDirect: string;
   };
 
 const fragment = graphql`

--- a/packages/admin/components/composed/ordering/EntityOrderingAddForm/EntityOrderingAddForm.tsx
+++ b/packages/admin/components/composed/ordering/EntityOrderingAddForm/EntityOrderingAddForm.tsx
@@ -13,6 +13,7 @@ import type {
   CreateOrderingInput,
   OrderDefinitionInput,
   OrderingSelectDefinitionInput,
+  OrderingDirectSelection,
 } from "@/relay/EntityOrderingAddFormMutation.graphql";
 import type { EntityOrderingAddFormFragment$key } from "@/relay/EntityOrderingAddFormFragment.graphql";
 
@@ -80,7 +81,7 @@ export default function EntityOrderingAddForm({
           name: data.name,
           identifier: `${convertToSlug(data?.name ?? undefined)}-${uid}`,
           order: getOrder(data.sortby),
-          select: { direct: data.selectDirect },
+          select: { direct: data.selectDirect as OrderingDirectSelection },
         },
       };
     },
@@ -90,9 +91,6 @@ export default function EntityOrderingAddForm({
   const defaultValues = {
     // Flatten select object into separate fields
     selectDirect: "CHILDREN",
-    entityId: undefined,
-    identifier: undefined,
-    order: { path: undefined, direction: undefined },
   };
 
   const renderForm = useRenderForm<Fields>(({ form: { register, watch } }) => {

--- a/packages/admin/components/forms/RadioGroup/Radio.tsx
+++ b/packages/admin/components/forms/RadioGroup/Radio.tsx
@@ -1,26 +1,19 @@
-import * as React from "react";
+import React, { forwardRef, Ref } from "react";
 import type { FieldValues } from "react-hook-form";
 import * as Styled from "./RadioGroup.styles";
 
-export default function Radio({
-  name,
-  value,
-  label,
-  order,
-  selected,
-  id,
-  ...props
-}: Props) {
+function Radio(
+  { name, value, label, order, id, ...props }: Props,
+  ref: Ref<HTMLInputElement>
+) {
   return (
     <Styled.Label htmlFor={id}>
       <Styled.Radio
         id={id}
         type="radio"
-        role="radio"
         value={value}
-        tabIndex={selected === value || (!selected && order === 1) ? 0 : -1}
-        aria-checked={selected === value}
         name={name}
+        ref={ref}
         {...props}
       />
       <Styled.LabelText className="t-copy-sm">{label}</Styled.LabelText>
@@ -32,6 +25,7 @@ interface Props extends FieldValues {
   value: string;
   label: string;
   order: number;
-  selected: string;
   id?: string;
 }
+
+export default forwardRef(Radio);

--- a/packages/admin/components/forms/RadioGroup/RadioGroup.tsx
+++ b/packages/admin/components/forms/RadioGroup/RadioGroup.tsx
@@ -1,4 +1,4 @@
-import React, { useState, forwardRef } from "react";
+import React, { forwardRef } from "react";
 import { useTranslation } from "react-i18next";
 import type InputProps from "../inputType";
 import Radio from "./Radio";
@@ -8,14 +8,10 @@ import BaseInputLabel from "components/forms/BaseInputLabel";
 const RadioGroup = forwardRef(
   (
     { label, name, description, options, hideLabel, ...props }: Props,
-    ref: React.Ref<HTMLDivElement>
+    // ref is passed to radio button input
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    ref: React.Ref<HTMLInputElement>
   ) => {
-    const defaultValue = options.filter((option) => option.default)[0]?.value;
-    const [selected, setSelected] = useState<string>(defaultValue ?? "");
-    const handleTabIndex = (e: React.ChangeEvent<HTMLInputElement>) => {
-      setSelected(e.target.value);
-    };
-
     const { t } = useTranslation();
 
     const radios = options.map((option, i) => (
@@ -26,17 +22,15 @@ const RadioGroup = forwardRef(
         order={i + 1}
         name={name}
         label={option.label}
-        onClick={handleTabIndex}
-        selected={selected}
-        checked={option.default}
+        ref={ref}
         {...props}
       />
     ));
+
     return (
       <Styled.Group
         role="radiogroup"
         aria-label={props["aria-label"] || undefined}
-        ref={ref}
       >
         <BaseInputLabel hideLabel={hideLabel}>{t(label)}</BaseInputLabel>
         {description && <Styled.Description>{description}</Styled.Description>}


### PR DESCRIPTION
- Removed "none" option (UX decision - doesn't make sense to not have children to order)
- Fixed radio erroring if changed after submit by flattening `select.direct` object to `selectDirect`
- Fixed radio value by passing react-hook-form's register ref down to the Radio's input element
- Removed controlled selected/checked attributes on Radio (these are already handled by react-hook-form)
- Removed aria-checked from Radio (shouldn't be needed since we're using a radio input)
- Removed tab index from Radio (letting the browser handle the radio's keyboard navigation)
- Removed undefined default values