### PR TITLE
[F] Simplify dynamic ordering form select inputs

### DIFF
--- a/packages/admin/__generated__/EntityOrderingAddDrawerQuery.graphql.ts
+++ b/packages/admin/__generated__/EntityOrderingAddDrawerQuery.graphql.ts
@@ -32,15 +32,6 @@ fragment EntityOrderingAddFormFragment on Query {
   item(slug: $entitySlug) {
     id
   }
-  schemaVersions {
-    edges {
-      node {
-        kind
-        identifier
-        id
-      }
-    }
-  }
 }
 */
 
@@ -59,15 +50,14 @@ v1 = [
     "variableName": "entitySlug"
   }
 ],
-v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v3 = [
-  (v2/*: any*/)
+v2 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "id",
+    "storageKey": null
+  }
 ];
 return {
   "fragment": {
@@ -98,7 +88,7 @@ return {
         "kind": "LinkedField",
         "name": "collection",
         "plural": false,
-        "selections": (v3/*: any*/),
+        "selections": (v2/*: any*/),
         "storageKey": null
       },
       {
@@ -108,66 +98,18 @@ return {
         "kind": "LinkedField",
         "name": "item",
         "plural": false,
-        "selections": (v3/*: any*/),
-        "storageKey": null
-      },
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": "SchemaVersionConnection",
-        "kind": "LinkedField",
-        "name": "schemaVersions",
-        "plural": false,
-        "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "SchemaVersionEdge",
-            "kind": "LinkedField",
-            "name": "edges",
-            "plural": true,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "SchemaVersion",
-                "kind": "LinkedField",
-                "name": "node",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "kind",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "identifier",
-                    "storageKey": null
-                  },
-                  (v2/*: any*/)
-                ],
-                "storageKey": null
-              }
-            ],
-            "storageKey": null
-          }
-        ],
+        "selections": (v2/*: any*/),
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "2fb3aaa25933b3d3418c6e07b4d7ad0d",
+    "cacheID": "0ed7dd467accab8ac908b85de06d9882",
     "id": null,
     "metadata": {},
     "name": "EntityOrderingAddDrawerQuery",
     "operationKind": "query",
-    "text": "query EntityOrderingAddDrawerQuery(\n  $entitySlug: Slug!\n) {\n  ...EntityOrderingAddFormFragment\n}\n\nfragment EntityOrderingAddFormFragment on Query {\n  collection(slug: $entitySlug) {\n    id\n  }\n  item(slug: $entitySlug) {\n    id\n  }\n  schemaVersions {\n    edges {\n      node {\n        kind\n        identifier\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query EntityOrderingAddDrawerQuery(\n  $entitySlug: Slug!\n) {\n  ...EntityOrderingAddFormFragment\n}\n\nfragment EntityOrderingAddFormFragment on Query {\n  collection(slug: $entitySlug) {\n    id\n  }\n  item(slug: $entitySlug) {\n    id\n  }\n}\n"
   }
 };
 })();

--- a/packages/admin/__generated__/EntityOrderingAddFormFragment.graphql.ts
+++ b/packages/admin/__generated__/EntityOrderingAddFormFragment.graphql.ts
@@ -5,7 +5,6 @@
 import { ReaderFragment } from "relay-runtime";
 
 import { FragmentRefs } from "relay-runtime";
-export type SchemaKind = "COLLECTION" | "COMMUNITY" | "ITEM" | "METADATA" | "%future added value";
 export type EntityOrderingAddFormFragment = {
     readonly collection: {
         readonly id: string;
@@ -13,14 +12,6 @@ export type EntityOrderingAddFormFragment = {
     readonly item: {
         readonly id: string;
     } | null;
-    readonly schemaVersions: {
-        readonly edges: ReadonlyArray<{
-            readonly node: {
-                readonly kind: SchemaKind;
-                readonly identifier: string;
-            };
-        }>;
-    };
     readonly " $refType": "EntityOrderingAddFormFragment";
 };
 export type EntityOrderingAddFormFragment$data = EntityOrderingAddFormFragment;
@@ -78,58 +69,11 @@ return {
       "plural": false,
       "selections": (v1/*: any*/),
       "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "SchemaVersionConnection",
-      "kind": "LinkedField",
-      "name": "schemaVersions",
-      "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "SchemaVersionEdge",
-          "kind": "LinkedField",
-          "name": "edges",
-          "plural": true,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "concreteType": "SchemaVersion",
-              "kind": "LinkedField",
-              "name": "node",
-              "plural": false,
-              "selections": [
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "kind",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "identifier",
-                  "storageKey": null
-                }
-              ],
-              "storageKey": null
-            }
-          ],
-          "storageKey": null
-        }
-      ],
-      "storageKey": null
     }
   ],
   "type": "Query",
   "abstractKey": null
 };
 })();
-(node as any).hash = 'bd6ba5f08157f7253dcfc483ab3bb775';
+(node as any).hash = '5875191369b27f342a694e3cdc3ebb20';
 export default node;

--- a/packages/admin/components/composed/ordering/EntityOrderingAddForm/EntityOrderingAddForm.tsx
+++ b/packages/admin/components/composed/ordering/EntityOrderingAddForm/EntityOrderingAddForm.tsx
@@ -6,49 +6,51 @@ import MutationForm, {
   useToVariables,
   Forms,
 } from "components/api/MutationForm";
+import { convertToSlug } from "helpers";
+import { useUID } from "react-uid";
 
 import type {
   EntityOrderingAddFormMutation,
   CreateOrderingInput,
   OrderDefinitionInput,
   OrderingSelectDefinitionInput,
-  OrderingFilterDefinitionInput,
 } from "@/relay/EntityOrderingAddFormMutation.graphql";
 import type { EntityOrderingAddFormFragment$key } from "@/relay/EntityOrderingAddFormFragment.graphql";
 
 const description = `Select descendants to be included in the ordering. Use Direct
 Descendants to select only immediate children, for example journal
-issues but not their articles. Descendants must be included for at
-least one type of entity.`;
+issues but not their articles.`;
 
 export default function EntityOrderingAddForm({
   data,
   onSuccess,
   onCancel,
 }: Props) {
-  const { t } = useTranslation();
+  const uid = useUID();
 
   const formData = useFragment<EntityOrderingAddFormFragment$key>(
     fragment,
     data
   );
-  const schemaOptions = formData.schemaVersions;
+  // const schemaOptions = formData.schemaVersions;
   const entity = formData.item ?? formData.collection;
 
-  const getFilter = (
-    items: OrderingSelectDefinitionInput["direct"] = "CHILDREN",
-    collections: OrderingSelectDefinitionInput["direct"] = "CHILDREN"
-  ): OrderingFilterDefinitionInput["schemas"] => {
-    if (items !== "NONE" && collections !== "NONE") return null;
-    if (items === "NONE")
-      return schemaOptions.edges
-        .filter((node) => node.node.kind === "ITEM")
-        .map((node) => node.node.identifier);
-    if (collections === "NONE")
-      return schemaOptions.edges
-        .filter((node) => node.node.kind === "COLLECTION")
-        .map((node) => node.node.identifier);
-  };
+  /*
+   *  const getFilter = (
+   *    items: OrderingSelectDefinitionInput["direct"] = "CHILDREN",
+   *    collections: OrderingSelectDefinitionInput["direct"] = "CHILDREN"
+   *  ): OrderingFilterDefinitionInput["schemas"] => {
+   *    if (items !== "NONE" && collections !== "NONE") return null;
+   *    if (items === "NONE")
+   *      return schemaOptions.edges
+   *        .filter((node) => node.node.kind === "ITEM")
+   *        .map((node) => node.node.identifier);
+   *    if (collections === "NONE")
+   *      return schemaOptions.edges
+   *        .filter((node) => node.node.kind === "COLLECTION")
+   *        .map((node) => node.node.identifier);
+   *  };
+   */
 
   const getOrder = (sortby: string): OrderDefinitionInput[] => {
     const [property, direction] = sortby.split(",");
@@ -70,77 +72,69 @@ export default function EntityOrderingAddForm({
   };
 
   const toVariables = useToVariables<EntityOrderingAddFormMutation, Fields>(
-    (data) => ({
-      input: {
-        entityId: entity?.id || "",
-        name: data.name,
-        /* Identifier should be `${convertToSlug(data.name)}-${uid} but the api errors if non-alpha characters are included.` */
-        identifier: data.name
-          ? data.name.toLowerCase().split(" ").join("")
-          : "",
-        filter: {
-          schemas: getFilter(data.items, data.collections),
+    (data) => {
+      console.log(data);
+      console.log(`${convertToSlug(data?.name ?? undefined)}-${uid}`);
+      return {
+        input: {
+          entityId: entity?.id || "",
+          name: data.name,
+          identifier: `${convertToSlug(data?.name ?? undefined)}-${uid}`,
+          order: getOrder(data.sortby),
         },
-        select: {
-          direct: data.collections !== "NONE" ? data.collections : data.items,
-        },
-        order: getOrder(data.sortby),
-      },
-    }),
+      };
+    },
     []
   );
 
+  const defaultValues = {
+    select: { direct: "CHILDREN" },
+    entityId: undefined,
+    identifier: undefined,
+    order: { path: undefined, direction: undefined },
+  };
+
   const renderForm = useRenderForm<Fields>(
-    ({ form: { register } }) => (
-      <Forms.Grid>
-        <Forms.Input
-          label={"forms.fields.displayname"}
-          required
-          {...register("name")}
-        />
-        <Forms.Select
-          label="forms.fields.sortby"
-          options={[
-            { value: "name, asc", label: "Name, ascending" },
-            { value: "name, desc", label: "Name, descending" },
-            { value: "updatedAt, asc", label: "Updated at, ascending" },
-            { value: "updatedAt, desc", label: "Updated at, descending" },
-            {
-              value: "published, asc",
-              label: "Publication date, ascending",
-            },
-            {
-              value: "published, desc",
-              label: "Publication date, descending",
-            },
-          ]}
-          {...register("sortby")}
-        />
-        <Forms.Fieldset
-          label={t("forms.fields.include")}
-          description={description}
-        >
+    ({ form: { register, getValues } }) => {
+      console.log(getValues());
+      return (
+        <Forms.Grid>
+          <Forms.Input
+            label={"forms.fields.displayname"}
+            required
+            {...register("name")}
+          />
+          <Forms.Select
+            label="forms.fields.sortby"
+            options={[
+              { value: "name, asc", label: "Name, ascending" },
+              { value: "name, desc", label: "Name, descending" },
+              { value: "updatedAt, asc", label: "Updated at, ascending" },
+              { value: "updatedAt, desc", label: "Updated at, descending" },
+              {
+                value: "published, asc",
+                label: "Publication date, ascending",
+              },
+              {
+                value: "published, desc",
+                label: "Publication date, descending",
+              },
+            ]}
+            {...register("sortby")}
+          />
           <Forms.RadioGroup
-            label="glossary.collection_plural"
-            {...register("collections")}
+            label="forms.fields.include"
+            description={description}
+            {...register("select.direct")}
             options={[
               { value: "NONE", label: "None" },
               { value: "CHILDREN", label: "Direct Descendants", default: true },
               { value: "DESCENDANTS", label: "All Descendants" },
             ]}
           />
-          <Forms.RadioGroup
-            label="glossary.item_plural"
-            {...register("items")}
-            options={[
-              { value: "NONE", label: "None" },
-              { value: "CHILDREN", label: "Direct Descendants", default: true },
-              { value: "DESCENDANTS", label: "All Descendants" },
-            ]}
-          />
-        </Forms.Fieldset>
-      </Forms.Grid>
-    ),
+        </Forms.Grid>
+      );
+    },
     []
   );
 
@@ -154,6 +148,7 @@ export default function EntityOrderingAddForm({
       name="createOrdering"
       refetchTags={["nodes"]}
       toVariables={toVariables}
+      defaultValues={defaultValues}
     >
       {renderForm}
     </MutationForm>
@@ -168,8 +163,6 @@ type Props = Pick<
 type Fields = Omit<CreateOrderingInput, "clientMutationId"> &
   OrderDefinitionInput &
   OrderingSelectDefinitionInput & {
-    collections: OrderingSelectDefinitionInput["direct"];
-    items: OrderingSelectDefinitionInput["direct"];
     sortby: string;
   };
 

--- a/packages/admin/components/composed/ordering/EntityOrderingAddForm/EntityOrderingAddForm.tsx
+++ b/packages/admin/components/composed/ordering/EntityOrderingAddForm/EntityOrderingAddForm.tsx
@@ -29,25 +29,7 @@ export default function EntityOrderingAddForm({
     fragment,
     data
   );
-  // const schemaOptions = formData.schemaVersions;
   const entity = formData.item ?? formData.collection;
-
-  /*
-   *  const getFilter = (
-   *    items: OrderingSelectDefinitionInput["direct"] = "CHILDREN",
-   *    collections: OrderingSelectDefinitionInput["direct"] = "CHILDREN"
-   *  ): OrderingFilterDefinitionInput["schemas"] => {
-   *    if (items !== "NONE" && collections !== "NONE") return null;
-   *    if (items === "NONE")
-   *      return schemaOptions.edges
-   *        .filter((node) => node.node.kind === "ITEM")
-   *        .map((node) => node.node.identifier);
-   *    if (collections === "NONE")
-   *      return schemaOptions.edges
-   *        .filter((node) => node.node.kind === "COLLECTION")
-   *        .map((node) => node.node.identifier);
-   *  };
-   */
 
   const getOrder = (sortby: string): OrderDefinitionInput[] => {
     const [property, direction] = sortby.split(",");
@@ -162,14 +144,6 @@ const fragment = graphql`
     }
     item(slug: $entitySlug) {
       id
-    }
-    schemaVersions {
-      edges {
-        node {
-          kind
-          identifier
-        }
-      }
     }
   }
 `;

--- a/packages/admin/components/composed/ordering/EntityOrderingAddForm/EntityOrderingAddForm.tsx
+++ b/packages/admin/components/composed/ordering/EntityOrderingAddForm/EntityOrderingAddForm.tsx
@@ -1,6 +1,5 @@
 import * as React from "react";
 import { graphql, useFragment } from "react-relay";
-import { useUID } from "react-uid";
 import MutationForm, {
   useRenderForm,
   useToVariables,
@@ -26,8 +25,6 @@ export default function EntityOrderingAddForm({
   onSuccess,
   onCancel,
 }: Props) {
-  const uid = useUID();
-
   const formData = useFragment<EntityOrderingAddFormFragment$key>(
     fragment,
     data
@@ -73,28 +70,24 @@ export default function EntityOrderingAddForm({
 
   const toVariables = useToVariables<EntityOrderingAddFormMutation, Fields>(
     (data) => {
-      console.log(data);
-      console.log(`${convertToSlug(data?.name ?? undefined)}-${uid}`);
-      return {
-        input: {
-          entityId: entity?.id || "",
-          name: data.name,
-          identifier: `${convertToSlug(data?.name ?? undefined)}-${uid}`,
-          order: getOrder(data.sortby),
-          select: { direct: data.selectDirect as OrderingDirectSelection },
-        },
+      const input = {
+        entityId: entity?.id || "",
+        name: data.name,
+        identifier: convertToSlug(data.name ?? undefined),
+        order: getOrder(data.sortby),
+        select: { direct: data.selectDirect },
       };
+      return { input: input };
     },
     []
   );
 
   const defaultValues = {
     // Flatten select object into separate fields
-    selectDirect: "CHILDREN",
+    selectDirect: "CHILDREN" as OrderingDirectSelection,
   };
 
-  const renderForm = useRenderForm<Fields>(({ form: { register, watch } }) => {
-    console.log(watch("selectDirect"));
+  const renderForm = useRenderForm<Fields>(({ form: { register } }) => {
     return (
       <Forms.Grid>
         <Forms.Input
@@ -159,7 +152,7 @@ type Fields = Omit<CreateOrderingInput, "clientMutationId" | "select"> &
   OrderDefinitionInput &
   OrderingSelectDefinitionInput & {
     sortby: string;
-    selectDirect: string;
+    selectDirect: OrderingDirectSelection;
   };
 
 const fragment = graphql`

--- a/packages/admin/components/forms/RadioGroup/Radio.tsx
+++ b/packages/admin/components/forms/RadioGroup/Radio.tsx
@@ -1,26 +1,19 @@
-import * as React from "react";
+import React, { forwardRef, Ref } from "react";
 import type { FieldValues } from "react-hook-form";
 import * as Styled from "./RadioGroup.styles";
 
-export default function Radio({
-  name,
-  value,
-  label,
-  order,
-  selected,
-  id,
-  ...props
-}: Props) {
+function Radio(
+  { name, value, label, order, id, ...props }: Props,
+  ref: Ref<HTMLInputElement>
+) {
   return (
     <Styled.Label htmlFor={id}>
       <Styled.Radio
         id={id}
         type="radio"
-        role="radio"
         value={value}
-        tabIndex={selected === value || (!selected && order === 1) ? 0 : -1}
-        aria-checked={selected === value}
         name={name}
+        ref={ref}
         {...props}
       />
       <Styled.LabelText className="t-copy-sm">{label}</Styled.LabelText>
@@ -32,6 +25,7 @@ interface Props extends FieldValues {
   value: string;
   label: string;
   order: number;
-  selected: string;
   id?: string;
 }
+
+export default forwardRef(Radio);

--- a/packages/admin/components/forms/RadioGroup/RadioGroup.stories.tsx
+++ b/packages/admin/components/forms/RadioGroup/RadioGroup.stories.tsx
@@ -19,7 +19,9 @@ export default {
 };
 
 export const InAForm: Story<Props> = (args) => {
-  const handleSubmit = (data: Record<string, string>) => console.info(data);
+  const handleSubmit = (data: Record<string, string>) => {
+    console.info(data);
+  };
 
   return (
     <NullForm<FieldValues> onSubmit={handleSubmit}>

--- a/packages/admin/components/forms/RadioGroup/RadioGroup.tsx
+++ b/packages/admin/components/forms/RadioGroup/RadioGroup.tsx
@@ -1,4 +1,4 @@
-import React, { useState, forwardRef } from "react";
+import React, { forwardRef } from "react";
 import { useTranslation } from "react-i18next";
 import type InputProps from "../inputType";
 import Radio from "./Radio";
@@ -8,14 +8,10 @@ import BaseInputLabel from "components/forms/BaseInputLabel";
 const RadioGroup = forwardRef(
   (
     { label, name, description, options, hideLabel, ...props }: Props,
-    ref: React.Ref<HTMLDivElement>
+    // ref is passed to radio button input
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    ref: React.Ref<HTMLInputElement>
   ) => {
-    const defaultValue = options.filter((option) => option.default)[0]?.value;
-    const [selected, setSelected] = useState<string>(defaultValue ?? "");
-    const handleTabIndex = (e: React.ChangeEvent<HTMLInputElement>) => {
-      setSelected(e.target.value);
-    };
-
     const { t } = useTranslation();
 
     const radios = options.map((option, i) => (
@@ -26,17 +22,15 @@ const RadioGroup = forwardRef(
         order={i + 1}
         name={name}
         label={option.label}
-        onClick={handleTabIndex}
-        selected={selected}
-        checked={option.default}
+        ref={ref}
         {...props}
       />
     ));
+
     return (
       <Styled.Group
         role="radiogroup"
         aria-label={props["aria-label"] || undefined}
-        ref={ref}
       >
         <BaseInputLabel hideLabel={hideLabel}>{t(label)}</BaseInputLabel>
         {description && <Styled.Description>{description}</Styled.Description>}

--- a/packages/admin/components/forms/RadioGroup/RadioGroup.tsx
+++ b/packages/admin/components/forms/RadioGroup/RadioGroup.tsx
@@ -10,9 +10,11 @@ const RadioGroup = forwardRef(
     { label, name, description, options, hideLabel, ...props }: Props,
     ref: React.Ref<HTMLDivElement>
   ) => {
-    const [selected, setSelected] = useState<string>("");
-    const handleTabIndex = (e: React.ChangeEvent<HTMLInputElement>) =>
+    const defaultValue = options.filter((option) => option.default)[0]?.value;
+    const [selected, setSelected] = useState<string>(defaultValue ?? "");
+    const handleTabIndex = (e: React.ChangeEvent<HTMLInputElement>) => {
       setSelected(e.target.value);
+    };
 
     const { t } = useTranslation();
 
@@ -24,7 +26,7 @@ const RadioGroup = forwardRef(
         order={i + 1}
         name={name}
         label={option.label}
-        onChange={handleTabIndex}
+        onClick={handleTabIndex}
         selected={selected}
         checked={option.default}
         {...props}

--- a/packages/admin/locales/en.json
+++ b/packages/admin/locales/en.json
@@ -281,7 +281,7 @@
         "profile": "Profile",
         "displayname": "Display Name",
         "sortby": "Sort By",
-        "include": "Records to Include"
+        "include": "Entities to Include"
       },
       "validation": {
         "year": "Must be a four digit year",


### PR DESCRIPTION
Combines `Collections` and `Items` inputs to a single `Entities to Include` input. Creates `identifier` as a slug based on `displayName`. Removes `filter`.