### PR TITLE
[F] Add view button to admin app

### DIFF
--- a/packages/admin/.env
+++ b/packages/admin/.env
@@ -3,4 +3,4 @@ NEXT_PUBLIC_KEYCLOAK_REALM=NGLP
 NEXT_PUBLIC_KEYCLOAK_CLIENT_ID=WDP
 NEXT_PUBLIC_API_URL=https://api.staging.nglp.org/graphql
 NEXT_PUBLIC_TUS_URL=https://api.staging.nglp.org/files
-NEXT_PUBLIC_FE_URL=https://frontend.staging.nglp.org/
+NEXT_PUBLIC_FE_URL=https://frontend.staging.nglp.org

--- a/packages/admin/.env
+++ b/packages/admin/.env
@@ -3,3 +3,4 @@ NEXT_PUBLIC_KEYCLOAK_REALM=NGLP
 NEXT_PUBLIC_KEYCLOAK_CLIENT_ID=WDP
 NEXT_PUBLIC_API_URL=https://api.staging.nglp.org/graphql
 NEXT_PUBLIC_TUS_URL=https://api.staging.nglp.org/files
+NEXT_PUBLIC_FE_URL=https://frontend.staging.nglp.org/

--- a/packages/admin/components/atomic/buttons/ButtonControl/index.ts
+++ b/packages/admin/components/atomic/buttons/ButtonControl/index.ts
@@ -3,6 +3,7 @@ import ButtonControlDrawer from "./patterns/ButtonControlDrawer";
 import ButtonControlConfirm from "./patterns/ButtonControlConfirm";
 import ButtonControlRoute from "./patterns/ButtonControlRoute";
 import ButtonControlDownload from "./patterns/ButtonControlDownload";
+import ButtonControlView from "./patterns/ButtonControlView";
 
 export default ButtonControl;
 export {
@@ -10,4 +11,5 @@ export {
   ButtonControlConfirm,
   ButtonControlRoute,
   ButtonControlDownload,
+  ButtonControlView,
 };

--- a/packages/admin/components/atomic/buttons/ButtonControl/patterns/ButtonControlView.tsx
+++ b/packages/admin/components/atomic/buttons/ButtonControl/patterns/ButtonControlView.tsx
@@ -1,0 +1,27 @@
+import React, { forwardRef } from "react";
+import { ButtonControl } from "components/atomic";
+type BaseProps = React.ComponentProps<typeof ButtonControl>;
+
+/**
+ * A button control that opens a drawer
+ */
+const ButtonControlView = forwardRef(({ children, ...props }: Props, ref) => {
+  return (
+    <ButtonControl
+      as="a"
+      icon="linkExternal"
+      ref={ref}
+      target="_blank"
+      {...props}
+    >
+      {children}
+    </ButtonControl>
+  );
+});
+
+interface Props extends Omit<BaseProps, "icon" | "iconRotate"> {
+  target?: "_blank" | "_self";
+  href: string;
+}
+
+export default ButtonControlView;

--- a/packages/admin/components/composed/collection/CollectionLayout/CollectionLayout.tsx
+++ b/packages/admin/components/composed/collection/CollectionLayout/CollectionLayout.tsx
@@ -59,7 +59,7 @@ export default function CollectionLayout({
       <ItemCreateButton parentSlug={slug} />
       <CollectionCreateButton parentSlug={slug} />
       <ButtonControlView
-        href={`${process.env.NEXT_PUBLIC_FE_URL}collections/${slug}`}
+        href={`${process.env.NEXT_PUBLIC_FE_URL}/collections/${slug}`}
       >
         {t("common.view")}
       </ButtonControlView>

--- a/packages/admin/components/composed/collection/CollectionLayout/CollectionLayout.tsx
+++ b/packages/admin/components/composed/collection/CollectionLayout/CollectionLayout.tsx
@@ -16,6 +16,7 @@ import {
 } from "hooks";
 import useBreadcrumbs from "hooks/useBreadcrumbs";
 import ItemCreateButton from "components/composed/item/ItemCreateButton";
+import { ButtonControlView } from "components/atomic/buttons/ButtonControl";
 
 export default function CollectionLayout({
   children,
@@ -57,6 +58,11 @@ export default function CollectionLayout({
     <ButtonControlGroup toggleLabel={t("options")} menuLabel={t("options")}>
       <ItemCreateButton parentSlug={slug} />
       <CollectionCreateButton parentSlug={slug} />
+      <ButtonControlView
+        href={`${process.env.NEXT_PUBLIC_FE_URL}collections/${slug}`}
+      >
+        {t("common.view")}
+      </ButtonControlView>
       <ButtonControlConfirm
         modalLabel={t("messages.delete.confirm_label")}
         modalBody={t("messages.delete.confirm_body")}

--- a/packages/admin/components/composed/collection/CollectionList/CollectionList.tsx
+++ b/packages/admin/components/composed/collection/CollectionList/CollectionList.tsx
@@ -50,7 +50,7 @@ function CollectionList<T extends OperationType>({
         row.original.title || "glossary.collection"
       ),
     handleView: ({ row }: ModelTableActionProps<CollectionNode>) =>
-      row.original.slug ? `collections/${row.original.slug}` : null,
+      row.original.slug ? `/collections/${row.original.slug}` : null,
   };
 
   const buttons = !hideHeader ? (

--- a/packages/admin/components/composed/collection/CollectionList/CollectionList.tsx
+++ b/packages/admin/components/composed/collection/CollectionList/CollectionList.tsx
@@ -49,6 +49,8 @@ function CollectionList<T extends OperationType>({
         { collectionId: row.original.id },
         row.original.title || "glossary.collection"
       ),
+    handleView: ({ row }: ModelTableActionProps<CollectionNode>) =>
+      row.original.slug ? `collections/${row.original.slug}` : null,
   };
 
   const buttons = !hideHeader ? (

--- a/packages/admin/components/composed/community/CommunityLayout/CommunityLayout.tsx
+++ b/packages/admin/components/composed/community/CommunityLayout/CommunityLayout.tsx
@@ -14,6 +14,7 @@ import {
 import { RouteHelper } from "routes";
 import { ButtonControlConfirm, ButtonControlGroup } from "components/atomic";
 import CollectionCreateButton from "components/composed/collection/CollectionCreateButton";
+import { ButtonControlView } from "components/atomic/buttons/ButtonControl";
 
 export default function CommunityLayout({
   children,
@@ -53,6 +54,11 @@ export default function CommunityLayout({
   const buttons = (
     <ButtonControlGroup toggleLabel={t("options")} menuLabel={t("options")}>
       <CollectionCreateButton parentSlug={slug} />
+      <ButtonControlView
+        href={`${process.env.NEXT_PUBLIC_FE_URL}communities/${slug}`}
+      >
+        {t("common.view")}
+      </ButtonControlView>
       <ButtonControlConfirm
         modalLabel={t("messages.delete.confirm_label")}
         modalBody={t("messages.delete.confirm_body")}

--- a/packages/admin/components/composed/community/CommunityLayout/CommunityLayout.tsx
+++ b/packages/admin/components/composed/community/CommunityLayout/CommunityLayout.tsx
@@ -55,7 +55,7 @@ export default function CommunityLayout({
     <ButtonControlGroup toggleLabel={t("options")} menuLabel={t("options")}>
       <CollectionCreateButton parentSlug={slug} />
       <ButtonControlView
-        href={`${process.env.NEXT_PUBLIC_FE_URL}communities/${slug}`}
+        href={`${process.env.NEXT_PUBLIC_FE_URL}/communities/${slug}`}
       >
         {t("common.view")}
       </ButtonControlView>

--- a/packages/admin/components/composed/community/CommunityList/CommunityList.tsx
+++ b/packages/admin/components/composed/community/CommunityList/CommunityList.tsx
@@ -45,7 +45,7 @@ function CommunityList<T extends OperationType>({
     handleDelete: ({ row }: ModelTableActionProps<CommunityNode>) =>
       destroy.community({ communityId: row.original.id }, row.original.name),
     handleView: ({ row }: ModelTableActionProps<CommunityNode>) =>
-      row.original.slug ? `communities/${row.original.slug}` : null,
+      row.original.slug ? `/communities/${row.original.slug}` : null,
   };
 
   const buttons = (

--- a/packages/admin/components/composed/community/CommunityList/CommunityList.tsx
+++ b/packages/admin/components/composed/community/CommunityList/CommunityList.tsx
@@ -44,6 +44,8 @@ function CommunityList<T extends OperationType>({
       drawerHelper.open("editCommunity", { drawerSlug: row.original.slug }),
     handleDelete: ({ row }: ModelTableActionProps<CommunityNode>) =>
       destroy.community({ communityId: row.original.id }, row.original.name),
+    handleView: ({ row }: ModelTableActionProps<CommunityNode>) =>
+      row.original.slug ? `communities/${row.original.slug}` : null,
   };
 
   const buttons = (

--- a/packages/admin/components/composed/item/ItemLayout/ItemLayout.tsx
+++ b/packages/admin/components/composed/item/ItemLayout/ItemLayout.tsx
@@ -15,6 +15,7 @@ import useBreadcrumbs from "hooks/useBreadcrumbs";
 import { RouteHelper } from "routes";
 import { ButtonControlGroup, ButtonControlConfirm } from "components/atomic";
 import { ContentSidebar, ContentHeader, PageHeader } from "components/layout";
+import { ButtonControlView } from "components/atomic/buttons/ButtonControl";
 
 export default function ItemLayout({
   children,
@@ -55,6 +56,11 @@ export default function ItemLayout({
   const buttons = (
     <ButtonControlGroup toggleLabel={t("options")} menuLabel={t("options")}>
       <ItemCreateButton parentSlug={slug} />
+      <ButtonControlView
+        href={`${process.env.NEXT_PUBLIC_FE_URL}items/${slug}`}
+      >
+        {t("common.view")}
+      </ButtonControlView>
       <ButtonControlConfirm
         modalLabel={t("messages.delete.confirm_label")}
         modalBody={t("messages.delete.confirm_body")}

--- a/packages/admin/components/composed/item/ItemLayout/ItemLayout.tsx
+++ b/packages/admin/components/composed/item/ItemLayout/ItemLayout.tsx
@@ -57,7 +57,7 @@ export default function ItemLayout({
     <ButtonControlGroup toggleLabel={t("options")} menuLabel={t("options")}>
       <ItemCreateButton parentSlug={slug} />
       <ButtonControlView
-        href={`${process.env.NEXT_PUBLIC_FE_URL}items/${slug}`}
+        href={`${process.env.NEXT_PUBLIC_FE_URL}/items/${slug}`}
       >
         {t("common.view")}
       </ButtonControlView>

--- a/packages/admin/components/composed/item/ItemList/ItemList.tsx
+++ b/packages/admin/components/composed/item/ItemList/ItemList.tsx
@@ -43,7 +43,7 @@ function ItemList<T extends OperationType>({
         row.original.title || "glossary.item"
       ),
     handleView: ({ row }: ModelTableActionProps<ItemNode>) =>
-      row.original.slug ? `items/${row.original.slug}` : null,
+      row.original.slug ? `/items/${row.original.slug}` : null,
   };
 
   return (

--- a/packages/admin/components/composed/item/ItemList/ItemList.tsx
+++ b/packages/admin/components/composed/item/ItemList/ItemList.tsx
@@ -42,6 +42,8 @@ function ItemList<T extends OperationType>({
         { itemId: row.original.id },
         row.original.title || "glossary.item"
       ),
+    handleView: ({ row }: ModelTableActionProps<ItemNode>) =>
+      row.original.slug ? `items/${row.original.slug}` : null,
   };
 
   return (

--- a/packages/admin/components/composed/model/ModelList/hooks/useModelList.tsx
+++ b/packages/admin/components/composed/model/ModelList/hooks/useModelList.tsx
@@ -12,6 +12,7 @@ interface Actions<T extends Record<string, unknown>> {
   handleEdit?: (props: ModelTableActionProps<T>) => void;
   handleDelete?: (props: ModelTableActionProps<T>) => void;
   handleDownload?: (props: ModelTableActionProps<T>) => void;
+  handleView?: (props: ModelTableActionProps<T>) => void;
 }
 
 export interface UseModelListProps<
@@ -74,6 +75,9 @@ function useModelList<
       }),
       ...(actions.handleDownload && {
         download: { handleLink: actions.handleDownload },
+      }),
+      ...(actions.handleView && {
+        view: { handleLink: actions.handleView },
       }),
     }),
     [actions]

--- a/packages/admin/components/composed/model/ModelList/hooks/useRowActions.tsx
+++ b/packages/admin/components/composed/model/ModelList/hooks/useRowActions.tsx
@@ -8,6 +8,7 @@ import {
   ButtonControlDownload,
 } from "components/atomic/buttons";
 import IconFactory from "components/factories/IconFactory";
+import { ButtonControlView } from "components/atomic/buttons/ButtonControl";
 type IconFactoryProps = React.ComponentProps<typeof IconFactory>;
 
 type ActionConfig<D extends Record<string, unknown>> = {
@@ -16,13 +17,13 @@ type ActionConfig<D extends Record<string, unknown>> = {
   handleLink?: ({ row }: { row: Row<D> }) => string;
 };
 
-type ActionKeys = "download" | "edit" | "delete";
+type ActionKeys = "download" | "edit" | "delete" | "view";
 
 interface ActionDefinition {
   label: string;
-  icon: IconFactoryProps["icon"];
-  action: string;
-  iconRotate: number;
+  icon?: IconFactoryProps["icon"];
+  action?: string;
+  iconRotate?: number;
   modalLabel?: string;
   modalBody?: React.ReactNode;
 }
@@ -37,26 +38,25 @@ type ActionConfigurations<D extends Record<string, unknown>> = {
 
 const availableActions: ActionDefinitions = {
   download: {
-    label: i18next.t("download"),
-    icon: "arrow",
+    label: i18next.t("common.download"),
     iconRotate: 180,
-    action: "",
   },
   edit: {
-    label: i18next.t("edit"),
+    label: i18next.t("common.edit"),
     icon: "edit",
     action: "self.update",
-    iconRotate: 0,
   },
   delete: {
-    label: i18next.t("delete"),
+    label: i18next.t("common.delete"),
     icon: "delete",
     action: "self.delete",
-    iconRotate: 0,
     modalLabel: i18next.t("messages.delete.confirm_label"),
     modalBody: (
       <p className="t-copy-sm">{i18next.t("messages.delete.confirm_body")}</p>
     ),
+  },
+  view: {
+    label: i18next.t("common.view"),
   },
 };
 
@@ -81,12 +81,20 @@ function getButtonControlChildren<D extends Record<string, unknown>>(
     ></ButtonControlConfirm>
   ) : action === "download" && actionConfig?.handleLink ? (
     <ButtonControlDownload
-      key="download"
+      key={action}
       aria-label={actionDefinition.label}
       {...(actionConfig?.handleLink && {
         href: actionConfig.handleLink({ row }),
       })}
     ></ButtonControlDownload>
+  ) : action === "view" && actionConfig?.handleLink ? (
+    <ButtonControlView
+      key={action}
+      aria-label={actionDefinition.label}
+      href={`${process.env.NEXT_PUBLIC_FE_URL}${actionConfig.handleLink({
+        row,
+      })}`}
+    />
   ) : (
     <ButtonControl
       key={action}

--- a/packages/admin/locales/en.json
+++ b/packages/admin/locales/en.json
@@ -19,6 +19,8 @@
       "edit": "Edit",
       "error": "Error",
       "delete": "Delete",
+      "download": "Download",
+      "view": "View",
       "loading": "Loading",
       "loading_ellipsis": "Loading...",
       "manage": "Manage",


### PR DESCRIPTION
Adds "View" links to the admin app and a NEXT_PUBLIC_FE_URL env variable. Clicking on this link will open the community, collection, or item in the frontend app. To change the link to your dev environment, add an `.env.local` file to `packages/admin`, and change the NEXT_PUBLIC_FE_URL to `http://localhost:3001`
<img width="1051" alt="Screen Shot 2021-12-10 at 9 45 10 AM" src="https://user-images.githubusercontent.com/57107444/145618338-029782ab-0f5c-4c1d-86b6-020297f5d221.png">
<img width="1069" alt="Screen Shot 2021-12-10 at 9 44 27 AM" src="https://user-images.githubusercontent.com/57107444/145618339-93bf337f-da03-4c5c-a1f4-782fe1f8c2c6.png">
