### PR TITLE
[F] Add content headers to article TOC

### DIFF
--- a/packages/admin/components/forms/FullTextInput/FullTextInput.tsx
+++ b/packages/admin/components/forms/FullTextInput/FullTextInput.tsx
@@ -51,27 +51,27 @@ const FullTextInput = forwardRef(
             name="kind"
             label={t("forms.full_text.kind_label")}
             options={options}
-            defaultValue={value?.kind || defaultValue?.kind}
-            onChange={handleChange}
+            defaultValue={value?.kind?.toUpperCase() || defaultValue?.kind}
             {...props}
+            onChange={handleChange}
             ref={kindRef}
           />
           <Input
             name="lang"
             label={t("forms.full_text.lang_label")}
-            onChange={handleChange}
             defaultValue={value?.lang || defaultValue?.lang}
-            ref={langRef}
             {...props}
+            onChange={handleChange}
+            ref={langRef}
           />
         </FormGrid>
         <Textarea
           name="content"
           label={t("forms.full_text.content_label")}
-          onChange={handleChange}
           defaultValue={value?.content || defaultValue?.content}
-          ref={contentRef}
           {...props}
+          onChange={handleChange}
+          ref={contentRef}
         />
       </Fieldset>
     );

--- a/packages/admin/pages/items/[slug]/manage/details.tsx
+++ b/packages/admin/pages/items/[slug]/manage/details.tsx
@@ -15,8 +15,8 @@ function ManageDetails({ data }: Props) {
       <SchemaInstanceForm
         instance={data?.item}
         schemaKind="ITEM"
-        successNotification="forms.item.update.schemaSuccess"
-        failureNotification="forms.item.update.schemaFailure"
+        successNotification="messages.update.item_success"
+        failureNotification="messages.update.item_failure"
       />
     </>
   ) : (

--- a/packages/frontend/components/composed/article/ArticleText/AnchorElement.tsx
+++ b/packages/frontend/components/composed/article/ArticleText/AnchorElement.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { convertToSlug } from "@wdp/lib/helpers";
+
+export default function AnchorElement({ as, anchor, ...props }: Props) {
+  const Tag = as;
+  const id = convertToSlug(anchor);
+
+  return <Tag id={id} {...props} />;
+}
+
+interface Props {
+  as: keyof JSX.IntrinsicElements | React.ElementType;
+  anchor: string;
+}

--- a/packages/frontend/components/composed/article/ArticleText/ArticleText.styles.ts
+++ b/packages/frontend/components/composed/article/ArticleText/ArticleText.styles.ts
@@ -16,12 +16,18 @@ export const TextBlock = styled.div`
   grid-area: text;
 `;
 
-export const TOCBlock = styled.div`
-  grid-area: toc;
-`;
-
 export const ImageBlock = styled.div`
   margin-block-end: var(--padding-lg);
+`;
+
+export const TOCBlock = styled.div`
+  grid-area: toc;
+  padding-block-end: ${pxToRem(100)};
+`;
+
+export const TOCInner = styled.div`
+  position: sticky;
+  top: var(--padding-lg);
 `;
 
 export const TOCHeader = styled.h5`

--- a/packages/frontend/components/composed/article/ArticleText/ArticleText.tsx
+++ b/packages/frontend/components/composed/article/ArticleText/ArticleText.tsx
@@ -1,48 +1,92 @@
-import React, { useMemo } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { graphql } from "react-relay";
 import ReactMarkdown from "react-markdown";
 import { useMaybeFragment } from "@wdp/lib/api/hooks";
+import { convertToSlug } from "@wdp/lib/helpers";
 import * as Styled from "./ArticleText.styles";
-import { ArticleTextFragment$key } from "@/relay/ArticleTextFragment.graphql";
 import { ContentImage } from "components/atomic";
 import { BackToTopBlock } from "components/layout";
+import { ArticleTextFragment$key } from "@/relay/ArticleTextFragment.graphql";
+
+type TOCItem = {
+  text: string;
+  id: string;
+};
 
 export default function ArticleText({ data }: Props) {
   const article = useMaybeFragment(fragment, data);
   const fullText = useMemo(() => article?.bodyText?.fullText, [article]);
+  const [toc, setTOC] = useState<TOCItem[]>();
+  const textEl = useRef<HTMLDivElement>(null);
+
+  /* Get all headers and set table of contents */
+  useEffect(() => {
+    const headerEls = textEl.current?.querySelectorAll("h1, h2, h3");
+
+    if (!headerEls || headerEls.length === 0) return;
+
+    const tocList: TOCItem[] = [];
+
+    [...headerEls].forEach((header) => {
+      const text = header.textContent;
+
+      if (!text) return;
+
+      const id = convertToSlug(text);
+      header.setAttribute("id", id);
+      tocList.push({ text, id });
+    });
+
+    setTOC(tocList);
+  }, [textEl]);
+
+  function renderContent() {
+    if (!fullText || !fullText.content) return;
+
+    switch (fullText.kind) {
+      case "HTML":
+        return (
+          <div
+            className="t-rte"
+            dangerouslySetInnerHTML={{ __html: fullText.content }}
+          />
+        );
+
+      case "MARKDOWN":
+        return (
+          <ReactMarkdown className="t-rte">{fullText.content}</ReactMarkdown>
+        );
+
+      default:
+        return <>{fullText.content}</>;
+    }
+  }
 
   return article && fullText ? (
     <Styled.BodyWrapper as={BackToTopBlock} className="l-container-wide">
       <Styled.BodyInner>
-        <Styled.TextBlock>
+        {toc && (
+          <Styled.TOCBlock>
+            <Styled.TOCInner>
+              <Styled.TOCHeader className="t-label-sm t-copy-light">
+                Table of Contents
+              </Styled.TOCHeader>
+              <Styled.TOCList>
+                {toc.map(({ id, text }, i: number) => (
+                  <Styled.TOCListItem key={i}>
+                    <a href={`#${id}`}>{text}</a>
+                  </Styled.TOCListItem>
+                ))}
+              </Styled.TOCList>
+            </Styled.TOCInner>
+          </Styled.TOCBlock>
+        )}
+        <Styled.TextBlock ref={textEl}>
           <Styled.ImageBlock>
             <ContentImage data={article.thumbnail} />
           </Styled.ImageBlock>
-          {fullText &&
-            (fullText.content && fullText.kind === "HTML" ? (
-              <div
-                className="t-rte"
-                dangerouslySetInnerHTML={{
-                  __html: fullText.content,
-                }}
-              />
-            ) : (
-              fullText.content && (
-                <ReactMarkdown className="t-rte">
-                  {fullText.content}
-                </ReactMarkdown>
-              )
-            ))}
+          {renderContent()}
         </Styled.TextBlock>
-        <Styled.TOCBlock>
-          <Styled.TOCHeader className="t-label-sm t-copy-light">
-            Table of Contents
-          </Styled.TOCHeader>
-          <Styled.TOCList>
-            <Styled.TOCListItem>Example Item</Styled.TOCListItem>
-            <Styled.TOCListItem>Example Item</Styled.TOCListItem>
-          </Styled.TOCList>
-        </Styled.TOCBlock>
       </Styled.BodyInner>
     </Styled.BodyWrapper>
   ) : (

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -52,6 +52,7 @@
     "react-relay": "^12.0.0",
     "react-relay-network-modern": "^6.0.0",
     "react-relay-network-modern-ssr": "^1.4.0",
+    "react-sanitized-html": "^2.0.0",
     "react-table": "^7.7.0",
     "react-transition-group": "^4.4.2",
     "react-uid": "^2.3.1",
@@ -60,6 +61,7 @@
     "relay-config": "^12.0.0",
     "relay-hooks": "^6.0.0",
     "relay-runtime": "^12.0.0",
+    "sanitize-html": "^2.6.1",
     "styled-components": "^5.3.0",
     "webpack": ">=2"
   },

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -18,7 +18,8 @@
       "@/relay/*": ["__generated__/*"]
       // "@/theme/*": ["theme/*"],
     },
-    "incremental": true
+    "incremental": true,
+    "downlevelIteration": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]

--- a/packages/lib/helpers/strings.ts
+++ b/packages/lib/helpers/strings.ts
@@ -6,3 +6,12 @@ export function formatFileSize(bytes: number, decimalPoint?: number): string {
   const i = Math.floor(Math.log(bytes) / Math.log(k));
   return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + " " + sizes[i];
 }
+
+export function convertToSlug(text?: string): string {
+  if (!text) return "";
+
+  return text
+    .toLowerCase()
+    .replace(/ /g, "-")
+    .replace(/[^\w-]+/g, "");
+}


### PR DESCRIPTION
- Currently blocked by an issue saving the FullTextProperty `body` on articles. Kind is always set to "TEXT".
- Fixes an issue with missing translations on backend when saving item schemas