### PR TITLE
[C] Add top border to RelatedArticles

### DIFF
--- a/packages/frontend/components/composed/article/RelatedArticles/RelatedArticles.styles.ts
+++ b/packages/frontend/components/composed/article/RelatedArticles/RelatedArticles.styles.ts
@@ -7,6 +7,14 @@ export const Inner = styled.div`
   padding-block-end: var(--container-padding-xlg);
 `;
 
+export const Outer = styled.section`
+  .a-bg-custom10 + & {
+    > ${Inner} {
+      border-top: 1px solid var(--color-base-neutral70);
+    }
+  }
+`;
+
 export const List = styled.ul`
   ${lGrid({
     rowGap: "var(--grid-row-gap-lg)",

--- a/packages/frontend/components/composed/article/RelatedArticles/RelatedArticles.tsx
+++ b/packages/frontend/components/composed/article/RelatedArticles/RelatedArticles.tsx
@@ -10,7 +10,7 @@ export default function RelatedArticles({ data }: Props) {
   const { t } = useTranslation();
   const articles = useMaybeFragment(fragment, data);
   return articles?.edges.length ? (
-    <section className="a-bg-custom10">
+    <Styled.Outer className="a-bg-custom10">
       <Styled.Inner className="l-container-wide">
         <h3 className="t-capitalize">{t("layouts.related_articles_header")}</h3>
         <Styled.List>
@@ -47,7 +47,7 @@ export default function RelatedArticles({ data }: Props) {
           ))}
         </Styled.List>
       </Styled.Inner>
-    </section>
+    </Styled.Outer>
   ) : null;
 }
 


### PR DESCRIPTION
Determined that there's no general way to determine when borders should be applied to .a-bg-custom10 elements and added border logic back to RelatedArticles.