### PR TITLE
[F] Reduce entity ambiguity

### DIFF
--- a/packages/admin/__generated__/EntityLinksAddFormMutation.graphql.ts
+++ b/packages/admin/__generated__/EntityLinksAddFormMutation.graphql.ts
@@ -40,10 +40,8 @@ mutation EntityLinksAddFormMutation(
     link {
       target {
         __typename
-        ... on Item {
-          title
-        }
-        ... on Collection {
+        ... on Entity {
+          __isEntity: __typename
           title
         }
         ... on Node {
@@ -88,28 +86,21 @@ v1 = [
     "variableName": "input"
   }
 ],
-v2 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "title",
-    "storageKey": null
-  }
-],
-v3 = {
+v2 = {
   "kind": "InlineFragment",
-  "selections": (v2/*: any*/),
-  "type": "Item",
-  "abstractKey": null
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "title",
+      "storageKey": null
+    }
+  ],
+  "type": "Entity",
+  "abstractKey": "__isEntity"
 },
-v4 = {
-  "kind": "InlineFragment",
-  "selections": (v2/*: any*/),
-  "type": "Collection",
-  "abstractKey": null
-},
-v5 = [
+v3 = [
   {
     "alias": null,
     "args": null,
@@ -118,7 +109,7 @@ v5 = [
     "storageKey": null
   }
 ],
-v6 = {
+v4 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -160,7 +151,7 @@ v6 = {
       "kind": "LinkedField",
       "name": "globalErrors",
       "plural": true,
-      "selections": (v5/*: any*/),
+      "selections": (v3/*: any*/),
       "storageKey": null
     },
     {
@@ -170,14 +161,14 @@ v6 = {
       "kind": "LinkedField",
       "name": "errors",
       "plural": true,
-      "selections": (v5/*: any*/),
+      "selections": (v3/*: any*/),
       "storageKey": null
     }
   ],
   "type": "StandardMutationPayload",
   "abstractKey": "__isStandardMutationPayload"
 },
-v7 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -215,8 +206,7 @@ return {
                 "name": "target",
                 "plural": false,
                 "selections": [
-                  (v3/*: any*/),
-                  (v4/*: any*/)
+                  (v2/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -227,7 +217,7 @@ return {
             "kind": "InlineDataFragmentSpread",
             "name": "MutationForm_mutationErrors",
             "selections": [
-              (v6/*: any*/)
+              (v4/*: any*/)
             ]
           }
         ],
@@ -274,12 +264,11 @@ return {
                     "name": "__typename",
                     "storageKey": null
                   },
-                  (v3/*: any*/),
-                  (v4/*: any*/),
+                  (v2/*: any*/),
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v7/*: any*/)
+                      (v5/*: any*/)
                     ],
                     "type": "Node",
                     "abstractKey": "__isNode"
@@ -287,25 +276,25 @@ return {
                 ],
                 "storageKey": null
               },
-              (v7/*: any*/)
+              (v5/*: any*/)
             ],
             "storageKey": null
           },
-          (v6/*: any*/)
+          (v4/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "317afdfd13a9719c52dd171aba8ba455",
+    "cacheID": "ef1bbfb93404e3a993f0c3a58b1497ed",
     "id": null,
     "metadata": {},
     "name": "EntityLinksAddFormMutation",
     "operationKind": "mutation",
-    "text": "mutation EntityLinksAddFormMutation(\n  $input: LinkEntityInput!\n) {\n  linkEntity(input: $input) {\n    link {\n      target {\n        __typename\n        ... on Item {\n          title\n        }\n        ... on Collection {\n          title\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n      id\n    }\n    ...MutationForm_mutationErrors\n  }\n}\n\nfragment MutationForm_mutationErrors on StandardMutationPayload {\n  __isStandardMutationPayload: __typename\n  attributeErrors {\n    path\n    type\n    messages\n  }\n  globalErrors {\n    message\n  }\n  errors {\n    message\n  }\n}\n"
+    "text": "mutation EntityLinksAddFormMutation(\n  $input: LinkEntityInput!\n) {\n  linkEntity(input: $input) {\n    link {\n      target {\n        __typename\n        ... on Entity {\n          __isEntity: __typename\n          title\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n      id\n    }\n    ...MutationForm_mutationErrors\n  }\n}\n\nfragment MutationForm_mutationErrors on StandardMutationPayload {\n  __isStandardMutationPayload: __typename\n  attributeErrors {\n    path\n    type\n    messages\n  }\n  globalErrors {\n    message\n  }\n  errors {\n    message\n  }\n}\n"
   }
 };
 })();
-(node as any).hash = '13f57c74b1e405c573518091a865b3ee';
+(node as any).hash = '2f1a3551aee9908b614cd7720ad10af3';
 export default node;

--- a/packages/admin/__generated__/EntityTitleFactoryFragment.graphql.ts
+++ b/packages/admin/__generated__/EntityTitleFactoryFragment.graphql.ts
@@ -1,0 +1,119 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+
+import { FragmentRefs } from "relay-runtime";
+export type EntityTitleFactoryFragment = {
+    readonly __typename: string;
+    readonly title: string;
+    readonly schemaVersion: {
+        readonly identifier: string;
+    };
+    readonly namedAncestors?: ReadonlyArray<{
+        readonly ancestor: {
+            readonly title?: string | undefined;
+        };
+    }> | undefined;
+    readonly " $refType": "EntityTitleFactoryFragment";
+};
+export type EntityTitleFactoryFragment$data = EntityTitleFactoryFragment;
+export type EntityTitleFactoryFragment$key = {
+    readonly " $data"?: EntityTitleFactoryFragment$data | undefined;
+    readonly " $fragmentRefs": FragmentRefs<"EntityTitleFactoryFragment">;
+};
+
+
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "title",
+  "storageKey": null
+},
+v1 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "NamedAncestor",
+    "kind": "LinkedField",
+    "name": "namedAncestors",
+    "plural": true,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "ancestor",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v0/*: any*/)
+            ],
+            "type": "Entity",
+            "abstractKey": "__isEntity"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "EntityTitleFactoryFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "__typename",
+      "storageKey": null
+    },
+    (v0/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "SchemaVersion",
+      "kind": "LinkedField",
+      "name": "schemaVersion",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "identifier",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "kind": "InlineFragment",
+      "selections": (v1/*: any*/),
+      "type": "Collection",
+      "abstractKey": null
+    },
+    {
+      "kind": "InlineFragment",
+      "selections": (v1/*: any*/),
+      "type": "Item",
+      "abstractKey": null
+    }
+  ],
+  "type": "Entity",
+  "abstractKey": "__isEntity"
+};
+})();
+(node as any).hash = 'bb78d9a2ceebc58a2bf1d57c39f0ad6b';
+export default node;

--- a/packages/admin/__generated__/EntityTitleFactoryFragment.graphql.ts
+++ b/packages/admin/__generated__/EntityTitleFactoryFragment.graphql.ts
@@ -6,16 +6,7 @@ import { ReaderFragment } from "relay-runtime";
 
 import { FragmentRefs } from "relay-runtime";
 export type EntityTitleFactoryFragment = {
-    readonly __typename: string;
-    readonly title: string;
-    readonly schemaVersion: {
-        readonly identifier: string;
-    };
-    readonly namedAncestors?: ReadonlyArray<{
-        readonly ancestor: {
-            readonly title?: string | undefined;
-        };
-    }> | undefined;
+    readonly " $fragmentRefs": FragmentRefs<"getEntityTitleFragment">;
     readonly " $refType": "EntityTitleFactoryFragment";
 };
 export type EntityTitleFactoryFragment$data = EntityTitleFactoryFragment;
@@ -73,47 +64,53 @@ return {
   "name": "EntityTitleFactoryFragment",
   "selections": [
     {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "__typename",
-      "storageKey": null
-    },
-    (v0/*: any*/),
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "SchemaVersion",
-      "kind": "LinkedField",
-      "name": "schemaVersion",
-      "plural": false,
+      "kind": "InlineDataFragmentSpread",
+      "name": "getEntityTitleFragment",
       "selections": [
         {
           "alias": null,
           "args": null,
           "kind": "ScalarField",
-          "name": "identifier",
+          "name": "__typename",
           "storageKey": null
+        },
+        (v0/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "SchemaVersion",
+          "kind": "LinkedField",
+          "name": "schemaVersion",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "identifier",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "kind": "InlineFragment",
+          "selections": (v1/*: any*/),
+          "type": "Collection",
+          "abstractKey": null
+        },
+        {
+          "kind": "InlineFragment",
+          "selections": (v1/*: any*/),
+          "type": "Item",
+          "abstractKey": null
         }
-      ],
-      "storageKey": null
-    },
-    {
-      "kind": "InlineFragment",
-      "selections": (v1/*: any*/),
-      "type": "Collection",
-      "abstractKey": null
-    },
-    {
-      "kind": "InlineFragment",
-      "selections": (v1/*: any*/),
-      "type": "Item",
-      "abstractKey": null
+      ]
     }
   ],
   "type": "Entity",
   "abstractKey": "__isEntity"
 };
 })();
-(node as any).hash = 'bb78d9a2ceebc58a2bf1d57c39f0ad6b';
+(node as any).hash = '81b9ae1337d3f472ff9b89e7bb0022df';
 export default node;

--- a/packages/admin/__generated__/LinkTargetTypeaheadFragment.graphql.ts
+++ b/packages/admin/__generated__/LinkTargetTypeaheadFragment.graphql.ts
@@ -10,15 +10,7 @@ export type LinkTargetTypeaheadFragment = {
         readonly node: {
             readonly targetId: string;
             readonly target: {
-                readonly __typename: "Collection";
-                readonly title: string;
-            } | {
-                readonly __typename: "Item";
-                readonly title: string;
-            } | {
-                /*This will never be '%other', but we need some
-                value in case none of the concrete values match.*/
-                readonly __typename: "%other";
+                readonly " $fragmentRefs": FragmentRefs<"EntityTitleFactoryFragment">;
             };
         };
     }>;
@@ -32,17 +24,7 @@ export type LinkTargetTypeaheadFragment$key = {
 
 
 
-const node: ReaderFragment = (function(){
-var v0 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "title",
-    "storageKey": null
-  }
-];
-return {
+const node: ReaderFragment = {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
@@ -80,23 +62,9 @@ return {
               "plural": false,
               "selections": [
                 {
-                  "alias": null,
                   "args": null,
-                  "kind": "ScalarField",
-                  "name": "__typename",
-                  "storageKey": null
-                },
-                {
-                  "kind": "InlineFragment",
-                  "selections": (v0/*: any*/),
-                  "type": "Collection",
-                  "abstractKey": null
-                },
-                {
-                  "kind": "InlineFragment",
-                  "selections": (v0/*: any*/),
-                  "type": "Item",
-                  "abstractKey": null
+                  "kind": "FragmentSpread",
+                  "name": "EntityTitleFactoryFragment"
                 }
               ],
               "storageKey": null
@@ -111,6 +79,5 @@ return {
   "type": "LinkTargetCandidateConnection",
   "abstractKey": null
 };
-})();
-(node as any).hash = 'e467703a74b65caadb97eda0a8e9bcc2';
+(node as any).hash = 'f590a146a76ee0fdf5fac56621e37ad8';
 export default node;

--- a/packages/admin/__generated__/LinkTargetTypeaheadFragment.graphql.ts
+++ b/packages/admin/__generated__/LinkTargetTypeaheadFragment.graphql.ts
@@ -10,7 +10,7 @@ export type LinkTargetTypeaheadFragment = {
         readonly node: {
             readonly targetId: string;
             readonly target: {
-                readonly " $fragmentRefs": FragmentRefs<"EntityTitleFactoryFragment">;
+                readonly " $fragmentRefs": FragmentRefs<"getEntityTitleFragment">;
             };
         };
     }>;
@@ -24,7 +24,47 @@ export type LinkTargetTypeaheadFragment$key = {
 
 
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "title",
+  "storageKey": null
+},
+v1 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "NamedAncestor",
+    "kind": "LinkedField",
+    "name": "namedAncestors",
+    "plural": true,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "ancestor",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v0/*: any*/)
+            ],
+            "type": "Entity",
+            "abstractKey": "__isEntity"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
@@ -62,9 +102,55 @@ const node: ReaderFragment = {
               "plural": false,
               "selections": [
                 {
-                  "args": null,
-                  "kind": "FragmentSpread",
-                  "name": "EntityTitleFactoryFragment"
+                  "kind": "InlineDataFragmentSpread",
+                  "name": "getEntityTitleFragment",
+                  "selections": [
+                    {
+                      "kind": "InlineFragment",
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "__typename",
+                          "storageKey": null
+                        },
+                        (v0/*: any*/),
+                        {
+                          "alias": null,
+                          "args": null,
+                          "concreteType": "SchemaVersion",
+                          "kind": "LinkedField",
+                          "name": "schemaVersion",
+                          "plural": false,
+                          "selections": [
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "identifier",
+                              "storageKey": null
+                            }
+                          ],
+                          "storageKey": null
+                        },
+                        {
+                          "kind": "InlineFragment",
+                          "selections": (v1/*: any*/),
+                          "type": "Collection",
+                          "abstractKey": null
+                        },
+                        {
+                          "kind": "InlineFragment",
+                          "selections": (v1/*: any*/),
+                          "type": "Item",
+                          "abstractKey": null
+                        }
+                      ],
+                      "type": "Entity",
+                      "abstractKey": "__isEntity"
+                    }
+                  ]
                 }
               ],
               "storageKey": null
@@ -79,5 +165,6 @@ const node: ReaderFragment = {
   "type": "LinkTargetCandidateConnection",
   "abstractKey": null
 };
-(node as any).hash = 'f590a146a76ee0fdf5fac56621e37ad8';
+})();
+(node as any).hash = 'e7a62872262d6481ce014b48e8d7e717';
 export default node;

--- a/packages/admin/__generated__/LinkTargetTypeaheadQuery.graphql.ts
+++ b/packages/admin/__generated__/LinkTargetTypeaheadQuery.graphql.ts
@@ -47,7 +47,24 @@ query LinkTargetTypeaheadQuery(
   }
 }
 
-fragment EntityTitleFactoryFragment on Entity {
+fragment LinkTargetTypeaheadFragment on LinkTargetCandidateConnection {
+  edges {
+    node {
+      targetId
+      target {
+        __typename
+        ...getEntityTitleFragment
+        ... on Node {
+          __isNode: __typename
+          id
+        }
+      }
+      id
+    }
+  }
+}
+
+fragment getEntityTitleFragment on Entity {
   __isEntity: __typename
   __typename
   title
@@ -83,23 +100,6 @@ fragment EntityTitleFactoryFragment on Entity {
           id
         }
       }
-    }
-  }
-}
-
-fragment LinkTargetTypeaheadFragment on LinkTargetCandidateConnection {
-  edges {
-    node {
-      targetId
-      target {
-        __typename
-        ...EntityTitleFactoryFragment
-        ... on Node {
-          __isNode: __typename
-          id
-        }
-      }
-      id
     }
   }
 }
@@ -369,12 +369,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6e7a39b60f33e3b3cc40873927307749",
+    "cacheID": "c946082b03d07e5fef7fd7b54fba1eb0",
     "id": null,
     "metadata": {},
     "name": "LinkTargetTypeaheadQuery",
     "operationKind": "query",
-    "text": "query LinkTargetTypeaheadQuery(\n  $slug: Slug!\n  $title: String\n) {\n  collection(slug: $slug) {\n    linkTargetCandidates(title: $title) {\n      ...LinkTargetTypeaheadFragment\n    }\n    id\n  }\n  item(slug: $slug) {\n    linkTargetCandidates(title: $title) {\n      ...LinkTargetTypeaheadFragment\n    }\n    id\n  }\n}\n\nfragment EntityTitleFactoryFragment on Entity {\n  __isEntity: __typename\n  __typename\n  title\n  schemaVersion {\n    identifier\n    id\n  }\n  ... on Collection {\n    namedAncestors {\n      ancestor {\n        __typename\n        ... on Entity {\n          __isEntity: __typename\n          title\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n  ... on Item {\n    namedAncestors {\n      ancestor {\n        __typename\n        ... on Entity {\n          __isEntity: __typename\n          title\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment LinkTargetTypeaheadFragment on LinkTargetCandidateConnection {\n  edges {\n    node {\n      targetId\n      target {\n        __typename\n        ...EntityTitleFactoryFragment\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n      id\n    }\n  }\n}\n"
+    "text": "query LinkTargetTypeaheadQuery(\n  $slug: Slug!\n  $title: String\n) {\n  collection(slug: $slug) {\n    linkTargetCandidates(title: $title) {\n      ...LinkTargetTypeaheadFragment\n    }\n    id\n  }\n  item(slug: $slug) {\n    linkTargetCandidates(title: $title) {\n      ...LinkTargetTypeaheadFragment\n    }\n    id\n  }\n}\n\nfragment LinkTargetTypeaheadFragment on LinkTargetCandidateConnection {\n  edges {\n    node {\n      targetId\n      target {\n        __typename\n        ...getEntityTitleFragment\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n      id\n    }\n  }\n}\n\nfragment getEntityTitleFragment on Entity {\n  __isEntity: __typename\n  __typename\n  title\n  schemaVersion {\n    identifier\n    id\n  }\n  ... on Collection {\n    namedAncestors {\n      ancestor {\n        __typename\n        ... on Entity {\n          __isEntity: __typename\n          title\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n  ... on Item {\n    namedAncestors {\n      ancestor {\n        __typename\n        ... on Entity {\n          __isEntity: __typename\n          title\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/packages/admin/__generated__/LinkTargetTypeaheadQuery.graphql.ts
+++ b/packages/admin/__generated__/LinkTargetTypeaheadQuery.graphql.ts
@@ -47,18 +47,53 @@ query LinkTargetTypeaheadQuery(
   }
 }
 
+fragment EntityTitleFactoryFragment on Entity {
+  __isEntity: __typename
+  __typename
+  title
+  schemaVersion {
+    identifier
+    id
+  }
+  ... on Collection {
+    namedAncestors {
+      ancestor {
+        __typename
+        ... on Entity {
+          __isEntity: __typename
+          title
+        }
+        ... on Node {
+          __isNode: __typename
+          id
+        }
+      }
+    }
+  }
+  ... on Item {
+    namedAncestors {
+      ancestor {
+        __typename
+        ... on Entity {
+          __isEntity: __typename
+          title
+        }
+        ... on Node {
+          __isNode: __typename
+          id
+        }
+      }
+    }
+  }
+}
+
 fragment LinkTargetTypeaheadFragment on LinkTargetCandidateConnection {
   edges {
     node {
       targetId
       target {
         __typename
-        ... on Collection {
-          title
-        }
-        ... on Item {
-          title
-        }
+        ...EntityTitleFactoryFragment
         ... on Node {
           __isNode: __typename
           id
@@ -115,23 +150,70 @@ v3 = [
     "storageKey": null
   }
 ],
-v4 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "title",
-    "storageKey": null
-  }
-],
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
 v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "title",
+  "storageKey": null
+},
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v6 = [
+v7 = {
+  "kind": "InlineFragment",
+  "selections": [
+    (v6/*: any*/)
+  ],
+  "type": "Node",
+  "abstractKey": "__isNode"
+},
+v8 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "NamedAncestor",
+    "kind": "LinkedField",
+    "name": "namedAncestors",
+    "plural": true,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "ancestor",
+        "plural": false,
+        "selections": [
+          (v4/*: any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v5/*: any*/)
+            ],
+            "type": "Entity",
+            "abstractKey": "__isEntity"
+          },
+          (v7/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+],
+v9 = [
   {
     "alias": null,
     "args": (v2/*: any*/),
@@ -171,37 +253,51 @@ v6 = [
                 "name": "target",
                 "plural": false,
                 "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "__typename",
-                    "storageKey": null
-                  },
-                  {
-                    "kind": "InlineFragment",
-                    "selections": (v4/*: any*/),
-                    "type": "Collection",
-                    "abstractKey": null
-                  },
-                  {
-                    "kind": "InlineFragment",
-                    "selections": (v4/*: any*/),
-                    "type": "Item",
-                    "abstractKey": null
-                  },
+                  (v4/*: any*/),
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v5/*: any*/)
+                      (v5/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "SchemaVersion",
+                        "kind": "LinkedField",
+                        "name": "schemaVersion",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "identifier",
+                            "storageKey": null
+                          },
+                          (v6/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "InlineFragment",
+                        "selections": (v8/*: any*/),
+                        "type": "Collection",
+                        "abstractKey": null
+                      },
+                      {
+                        "kind": "InlineFragment",
+                        "selections": (v8/*: any*/),
+                        "type": "Item",
+                        "abstractKey": null
+                      }
                     ],
-                    "type": "Node",
-                    "abstractKey": "__isNode"
-                  }
+                    "type": "Entity",
+                    "abstractKey": "__isEntity"
+                  },
+                  (v7/*: any*/)
                 ],
                 "storageKey": null
               },
-              (v5/*: any*/)
+              (v6/*: any*/)
             ],
             "storageKey": null
           }
@@ -211,7 +307,7 @@ v6 = [
     ],
     "storageKey": null
   },
-  (v5/*: any*/)
+  (v6/*: any*/)
 ];
 return {
   "fragment": {
@@ -257,7 +353,7 @@ return {
         "kind": "LinkedField",
         "name": "collection",
         "plural": false,
-        "selections": (v6/*: any*/),
+        "selections": (v9/*: any*/),
         "storageKey": null
       },
       {
@@ -267,18 +363,18 @@ return {
         "kind": "LinkedField",
         "name": "item",
         "plural": false,
-        "selections": (v6/*: any*/),
+        "selections": (v9/*: any*/),
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "18301b5ec518593809b8da677dfb179d",
+    "cacheID": "6e7a39b60f33e3b3cc40873927307749",
     "id": null,
     "metadata": {},
     "name": "LinkTargetTypeaheadQuery",
     "operationKind": "query",
-    "text": "query LinkTargetTypeaheadQuery(\n  $slug: Slug!\n  $title: String\n) {\n  collection(slug: $slug) {\n    linkTargetCandidates(title: $title) {\n      ...LinkTargetTypeaheadFragment\n    }\n    id\n  }\n  item(slug: $slug) {\n    linkTargetCandidates(title: $title) {\n      ...LinkTargetTypeaheadFragment\n    }\n    id\n  }\n}\n\nfragment LinkTargetTypeaheadFragment on LinkTargetCandidateConnection {\n  edges {\n    node {\n      targetId\n      target {\n        __typename\n        ... on Collection {\n          title\n        }\n        ... on Item {\n          title\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n      id\n    }\n  }\n}\n"
+    "text": "query LinkTargetTypeaheadQuery(\n  $slug: Slug!\n  $title: String\n) {\n  collection(slug: $slug) {\n    linkTargetCandidates(title: $title) {\n      ...LinkTargetTypeaheadFragment\n    }\n    id\n  }\n  item(slug: $slug) {\n    linkTargetCandidates(title: $title) {\n      ...LinkTargetTypeaheadFragment\n    }\n    id\n  }\n}\n\nfragment EntityTitleFactoryFragment on Entity {\n  __isEntity: __typename\n  __typename\n  title\n  schemaVersion {\n    identifier\n    id\n  }\n  ... on Collection {\n    namedAncestors {\n      ancestor {\n        __typename\n        ... on Entity {\n          __isEntity: __typename\n          title\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n  ... on Item {\n    namedAncestors {\n      ancestor {\n        __typename\n        ... on Entity {\n          __isEntity: __typename\n          title\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment LinkTargetTypeaheadFragment on LinkTargetCandidateConnection {\n  edges {\n    node {\n      targetId\n      target {\n        __typename\n        ...EntityTitleFactoryFragment\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n      id\n    }\n  }\n}\n"
   }
 };
 })();

--- a/packages/admin/__generated__/getEntityTitleFragment.graphql.ts
+++ b/packages/admin/__generated__/getEntityTitleFragment.graphql.ts
@@ -1,0 +1,34 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderInlineDataFragment } from "relay-runtime";
+
+import { FragmentRefs } from "relay-runtime";
+export type getEntityTitleFragment = {
+    readonly __typename: string;
+    readonly title: string;
+    readonly schemaVersion: {
+        readonly identifier: string;
+    };
+    readonly namedAncestors?: ReadonlyArray<{
+        readonly ancestor: {
+            readonly title?: string | undefined;
+        };
+    }> | undefined;
+    readonly " $refType": "getEntityTitleFragment";
+};
+export type getEntityTitleFragment$data = getEntityTitleFragment;
+export type getEntityTitleFragment$key = {
+    readonly " $data"?: getEntityTitleFragment$data | undefined;
+    readonly " $fragmentRefs": FragmentRefs<"getEntityTitleFragment">;
+};
+
+
+
+const node: ReaderInlineDataFragment = {
+  "kind": "InlineDataFragment",
+  "name": "getEntityTitleFragment"
+};
+(node as any).hash = 'b2c655a56c2308a93728710382f17ecd';
+export default node;

--- a/packages/admin/components/composed/links/EntityLinksAddForm/EntityLinksAddForm.tsx
+++ b/packages/admin/components/composed/links/EntityLinksAddForm/EntityLinksAddForm.tsx
@@ -44,8 +44,8 @@ export default function EntityLinksAddForm({
         <Forms.Select
           label="forms.fields.link_type"
           options={[
-            { value: "CONTAINS", label: "contains" },
-            { value: "REFERENCES", label: "references" },
+            { value: "CONTAINS", label: "Contains" },
+            { value: "REFERENCES", label: "References" },
           ]}
           description={t("forms.fields.link_type_description", {
             name: sourceEntity.title,
@@ -101,10 +101,7 @@ const mutation = graphql`
     linkEntity(input: $input) {
       link {
         target {
-          ... on Item {
-            title
-          }
-          ... on Collection {
+          ... on Entity {
             title
           }
         }

--- a/packages/admin/components/factories/EntityTitleFactory/EntityTitleFactory.tsx
+++ b/packages/admin/components/factories/EntityTitleFactory/EntityTitleFactory.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { graphql, useFragment } from "react-relay";
 import { EntityTitleFactoryFragment$key } from "@/relay/EntityTitleFactoryFragment.graphql";
 
@@ -11,7 +10,8 @@ export default function EntityTitleFactory({ data }: Props) {
     case "journal_volume":
       return (
         <>
-          {ancestors ? [entity.title, ...ancestors].join(": ") : entity.title}
+          `${ancestors ? [entity.title, ...ancestors].join(": ") : entity.title}
+          `
         </>
       );
     default:

--- a/packages/admin/components/factories/EntityTitleFactory/EntityTitleFactory.tsx
+++ b/packages/admin/components/factories/EntityTitleFactory/EntityTitleFactory.tsx
@@ -1,22 +1,11 @@
 import { graphql, useFragment } from "react-relay";
+import getEntityTitle from "./getEntityTitle";
 import { EntityTitleFactoryFragment$key } from "@/relay/EntityTitleFactoryFragment.graphql";
 
 export default function EntityTitleFactory({ data }: Props) {
   const entity = useFragment(fragment, data);
-  const ancestors = entity.namedAncestors?.map((node) => node.ancestor.title);
 
-  switch (entity.schemaVersion.identifier) {
-    case "journal_issue":
-    case "journal_volume":
-      return (
-        <>
-          `${ancestors ? [entity.title, ...ancestors].join(": ") : entity.title}
-          `
-        </>
-      );
-    default:
-      return <>{entity.title}</>;
-  }
+  return getEntityTitle(entity);
 }
 
 interface Props {
@@ -25,30 +14,6 @@ interface Props {
 
 const fragment = graphql`
   fragment EntityTitleFactoryFragment on Entity {
-    __typename
-    title
-    schemaVersion {
-      identifier
-    }
-
-    ... on Collection {
-      namedAncestors {
-        ancestor {
-          ... on Entity {
-            title
-          }
-        }
-      }
-    }
-
-    ... on Item {
-      namedAncestors {
-        ancestor {
-          ... on Entity {
-            title
-          }
-        }
-      }
-    }
+    ...getEntityTitleFragment
   }
 `;

--- a/packages/admin/components/factories/EntityTitleFactory/EntityTitleFactory.tsx
+++ b/packages/admin/components/factories/EntityTitleFactory/EntityTitleFactory.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { graphql, useFragment } from "react-relay";
+import { EntityTitleFactoryFragment$key } from "@/relay/EntityTitleFactoryFragment.graphql";
+
+export default function EntityTitleFactory({ data }: Props) {
+  const entity = useFragment(fragment, data);
+  const ancestors = entity.namedAncestors?.map((node) => node.ancestor.title);
+
+  switch (entity.schemaVersion.identifier) {
+    case "journal_issue":
+    case "journal_volume":
+      return (
+        <>
+          {ancestors ? [entity.title, ...ancestors].join(": ") : entity.title}
+        </>
+      );
+    default:
+      return <>{entity.title}</>;
+  }
+}
+
+interface Props {
+  data: EntityTitleFactoryFragment$key;
+}
+
+const fragment = graphql`
+  fragment EntityTitleFactoryFragment on Entity {
+    __typename
+    title
+    schemaVersion {
+      identifier
+    }
+
+    ... on Collection {
+      namedAncestors {
+        ancestor {
+          ... on Entity {
+            title
+          }
+        }
+      }
+    }
+
+    ... on Item {
+      namedAncestors {
+        ancestor {
+          ... on Entity {
+            title
+          }
+        }
+      }
+    }
+  }
+`;

--- a/packages/admin/components/factories/EntityTitleFactory/getEntityTitle.ts
+++ b/packages/admin/components/factories/EntityTitleFactory/getEntityTitle.ts
@@ -1,0 +1,50 @@
+import { graphql, readInlineData } from "react-relay";
+import { getEntityTitleFragment$key } from "@/relay/getEntityTitleFragment.graphql";
+
+export default function getEntityTitle(data: Props) {
+  const entity = readInlineData(fragment, data);
+
+  const ancestors = entity.namedAncestors?.map((node) => node.ancestor.title);
+
+  switch (entity.schemaVersion.identifier) {
+    case "journal_issue":
+    case "journal_volume":
+      return `${
+        ancestors ? [entity.title, ...ancestors].join(": ") : entity.title
+      }`;
+    default:
+      return entity.title;
+  }
+}
+
+type Props = getEntityTitleFragment$key;
+
+const fragment = graphql`
+  fragment getEntityTitleFragment on Entity @inline {
+    __typename
+    title
+    schemaVersion {
+      identifier
+    }
+
+    ... on Collection {
+      namedAncestors {
+        ancestor {
+          ... on Entity {
+            title
+          }
+        }
+      }
+    }
+
+    ... on Item {
+      namedAncestors {
+        ancestor {
+          ... on Entity {
+            title
+          }
+        }
+      }
+    }
+  }
+`;

--- a/packages/admin/components/factories/EntityTitleFactory/index.ts
+++ b/packages/admin/components/factories/EntityTitleFactory/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./EntityTitleFactory";

--- a/packages/admin/components/factories/EntityTitleFactory/index.ts
+++ b/packages/admin/components/factories/EntityTitleFactory/index.ts
@@ -1,1 +1,2 @@
 export { default } from "./EntityTitleFactory";
+export { default as getEntityTitle } from "./getEntityTitle";

--- a/packages/admin/components/factories/index.tsx
+++ b/packages/admin/components/factories/index.tsx
@@ -1,1 +1,2 @@
 export { default as IconFactory } from "./IconFactory";
+export { default as EntityTitleFactory } from "./EntityTitleFactory";

--- a/packages/admin/components/forms/BaseTypeahead/BaseTypeahead.tsx
+++ b/packages/admin/components/forms/BaseTypeahead/BaseTypeahead.tsx
@@ -101,7 +101,7 @@ const Typeahead = forwardRef(
 );
 
 interface Option {
-  label: string | React.ReactNode;
+  label: string;
   node?: React.ReactNode;
   value: number | string;
 }

--- a/packages/admin/components/forms/BaseTypeahead/BaseTypeahead.tsx
+++ b/packages/admin/components/forms/BaseTypeahead/BaseTypeahead.tsx
@@ -101,9 +101,9 @@ const Typeahead = forwardRef(
 );
 
 interface Option {
-  label: string;
+  label: string | React.ReactNode;
   node?: React.ReactNode;
-  value: string | number;
+  value: number | string;
 }
 interface Props extends Omit<InputProps, "onChange"> {
   options?: Option[];

--- a/packages/admin/components/forms/LinkTargetTypeahead/LinkTargetTypeahead.tsx
+++ b/packages/admin/components/forms/LinkTargetTypeahead/LinkTargetTypeahead.tsx
@@ -4,7 +4,6 @@ import { debounce } from "lodash";
 import type { FieldValues, Control, Path } from "react-hook-form";
 import { Controller } from "react-hook-form";
 import useAuthenticatedQuery from "@wdp/lib/api/hooks/useAuthenticatedQuery";
-import ReactDOMServer from "react-dom/server";
 import { useMaybeFragment } from "hooks";
 import { LinkTargetTypeaheadQuery as Query } from "@/relay/LinkTargetTypeaheadQuery.graphql";
 import {
@@ -12,7 +11,7 @@ import {
   LinkTargetTypeaheadFragment$key,
 } from "@/relay/LinkTargetTypeaheadFragment.graphql";
 import BaseTypeahead from "components/forms/BaseTypeahead";
-import { EntityTitleFactory } from "components/factories";
+import { getEntityTitle } from "components/factories/EntityTitleFactory";
 type TypeaheadProps = React.ComponentProps<typeof BaseTypeahead>;
 type Edge = LinkTargetTypeaheadFragment$data["edges"][number];
 
@@ -33,14 +32,10 @@ const LinkTargetTypeahead = <T extends FieldValues = FieldValues>({
   );
 
   const options = useMemo(() => {
-    const options = optionsData?.edges?.map((edge: Edge) => {
-      return {
-        label: ReactDOMServer.renderToString(
-          <EntityTitleFactory data={edge.node.target} />
-        ),
-        value: edge.node.targetId,
-      };
-    });
+    const options = optionsData?.edges?.map((edge: Edge) => ({
+      label: getEntityTitle(edge.node.target),
+      value: edge.node.targetId,
+    }));
 
     return options;
   }, [optionsData]);
@@ -100,7 +95,7 @@ const fragment = graphql`
       node {
         targetId
         target {
-          ...EntityTitleFactoryFragment
+          ...getEntityTitleFragment
         }
       }
     }

--- a/packages/admin/components/forms/LinkTargetTypeahead/LinkTargetTypeahead.tsx
+++ b/packages/admin/components/forms/LinkTargetTypeahead/LinkTargetTypeahead.tsx
@@ -4,6 +4,7 @@ import { debounce } from "lodash";
 import type { FieldValues, Control, Path } from "react-hook-form";
 import { Controller } from "react-hook-form";
 import useAuthenticatedQuery from "@wdp/lib/api/hooks/useAuthenticatedQuery";
+import ReactDOMServer from "react-dom/server";
 import { useMaybeFragment } from "hooks";
 import { LinkTargetTypeaheadQuery as Query } from "@/relay/LinkTargetTypeaheadQuery.graphql";
 import {
@@ -34,7 +35,9 @@ const LinkTargetTypeahead = <T extends FieldValues = FieldValues>({
   const options = useMemo(() => {
     const options = optionsData?.edges?.map((edge: Edge) => {
       return {
-        label: <EntityTitleFactory data={edge.node.target} />,
+        label: ReactDOMServer.renderToString(
+          <EntityTitleFactory data={edge.node.target} />
+        ),
         value: edge.node.targetId,
       };
     });

--- a/packages/admin/components/forms/LinkTargetTypeahead/LinkTargetTypeahead.tsx
+++ b/packages/admin/components/forms/LinkTargetTypeahead/LinkTargetTypeahead.tsx
@@ -11,6 +11,7 @@ import {
   LinkTargetTypeaheadFragment$key,
 } from "@/relay/LinkTargetTypeaheadFragment.graphql";
 import BaseTypeahead from "components/forms/BaseTypeahead";
+import { EntityTitleFactory } from "components/factories";
 type TypeaheadProps = React.ComponentProps<typeof BaseTypeahead>;
 type Edge = LinkTargetTypeaheadFragment$data["edges"][number];
 
@@ -32,12 +33,9 @@ const LinkTargetTypeahead = <T extends FieldValues = FieldValues>({
 
   const options = useMemo(() => {
     const options = optionsData?.edges?.map((edge: Edge) => {
-      const targetId = edge.node.targetId;
-      const title =
-        edge.node.target.__typename !== "%other" && edge.node.target.title;
       return {
-        label: title || "",
-        value: targetId,
+        label: <EntityTitleFactory data={edge.node.target} />,
+        value: edge.node.targetId,
       };
     });
 
@@ -99,14 +97,7 @@ const fragment = graphql`
       node {
         targetId
         target {
-          __typename
-          ... on Collection {
-            title
-          }
-
-          ... on Item {
-            title
-          }
+          ...EntityTitleFactoryFragment
         }
       }
     }


### PR DESCRIPTION
Try adding a link to view the updated names: [https://wdp-admin-git-jw-wdp-565-entity-ambiguity-cast-iron.vercel.app/collections/Gbmp657cxaQKTBdnF8BGDtrwG3GOenb/manage/links](https://wdp-admin-git-jw-wdp-565-entity-ambiguity-cast-iron.vercel.app/collections/Gbmp657cxaQKTBdnF8BGDtrwG3GOenb/manage/links) 

Gets a list of ancestors for Issues and Volumes
<img width="640" alt="Screen Shot 2022-01-31 at 9 24 33 AM" src="https://user-images.githubusercontent.com/57107444/151842421-2e21ac24-46d2-4c3e-b82f-d27756a7d13b.png">
