### PR TITLE
[WIP][F] Fetch meta tag data server side

### DIFF
--- a/packages/frontend/__generated__/AppHtmlHeadFragment.graphql.ts
+++ b/packages/frontend/__generated__/AppHtmlHeadFragment.graphql.ts
@@ -1,0 +1,93 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from "relay-runtime";
+
+import { FragmentRefs } from "relay-runtime";
+export type AppHtmlHeadFragment = {
+    readonly globalConfiguration: {
+        readonly site: {
+            readonly providerName: string;
+            readonly installationName: string;
+            readonly footer: {
+                readonly description: string;
+            };
+        };
+    };
+    readonly " $refType": "AppHtmlHeadFragment";
+};
+export type AppHtmlHeadFragment$data = AppHtmlHeadFragment;
+export type AppHtmlHeadFragment$key = {
+    readonly " $data"?: AppHtmlHeadFragment$data | undefined;
+    readonly " $fragmentRefs": FragmentRefs<"AppHtmlHeadFragment">;
+};
+
+
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "AppHtmlHeadFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "GlobalConfiguration",
+      "kind": "LinkedField",
+      "name": "globalConfiguration",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "SiteSettings",
+          "kind": "LinkedField",
+          "name": "site",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "providerName",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "installationName",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "SiteFooter",
+              "kind": "LinkedField",
+              "name": "footer",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "description",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Query",
+  "abstractKey": null
+};
+(node as any).hash = 'c147f5d7a5d3d104a4b9971610a6be1e';
+export default node;

--- a/packages/frontend/__generated__/pagesIndexQuery.graphql.ts
+++ b/packages/frontend/__generated__/pagesIndexQuery.graphql.ts
@@ -1,0 +1,174 @@
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from "relay-runtime";
+
+import { FragmentRefs } from "relay-runtime";
+export type pagesIndexQueryVariables = {};
+export type pagesIndexQueryResponse = {
+    readonly globalConfiguration: {
+        readonly site: {
+            readonly providerName: string;
+            readonly installationName: string;
+        };
+    };
+    readonly " $fragmentRefs": FragmentRefs<"AppHtmlHeadFragment">;
+};
+export type pagesIndexQuery = {
+    readonly response: pagesIndexQueryResponse;
+    readonly variables: pagesIndexQueryVariables;
+};
+
+
+
+/*
+query pagesIndexQuery {
+  globalConfiguration {
+    site {
+      providerName
+      installationName
+    }
+    id
+  }
+  ...AppHtmlHeadFragment
+}
+
+fragment AppHtmlHeadFragment on Query {
+  globalConfiguration {
+    site {
+      providerName
+      installationName
+      footer {
+        description
+      }
+    }
+    id
+  }
+}
+*/
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "providerName",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "installationName",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "pagesIndexQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "GlobalConfiguration",
+        "kind": "LinkedField",
+        "name": "globalConfiguration",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "SiteSettings",
+            "kind": "LinkedField",
+            "name": "site",
+            "plural": false,
+            "selections": [
+              (v0/*: any*/),
+              (v1/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      },
+      {
+        "args": null,
+        "kind": "FragmentSpread",
+        "name": "AppHtmlHeadFragment"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "pagesIndexQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "GlobalConfiguration",
+        "kind": "LinkedField",
+        "name": "globalConfiguration",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "SiteSettings",
+            "kind": "LinkedField",
+            "name": "site",
+            "plural": false,
+            "selections": [
+              (v0/*: any*/),
+              (v1/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "SiteFooter",
+                "kind": "LinkedField",
+                "name": "footer",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "description",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "36b06976225e913010ee5ff048373cec",
+    "id": null,
+    "metadata": {},
+    "name": "pagesIndexQuery",
+    "operationKind": "query",
+    "text": "query pagesIndexQuery {\n  globalConfiguration {\n    site {\n      providerName\n      installationName\n    }\n    id\n  }\n  ...AppHtmlHeadFragment\n}\n\nfragment AppHtmlHeadFragment on Query {\n  globalConfiguration {\n    site {\n      providerName\n      installationName\n      footer {\n        description\n      }\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+(node as any).hash = '9bc4edaf3a3c7fe8bac99754c6899184';
+export default node;

--- a/packages/frontend/components/global/AppHtmlHead/AppHtmlHead.tsx
+++ b/packages/frontend/components/global/AppHtmlHead/AppHtmlHead.tsx
@@ -1,9 +1,28 @@
+import { graphql } from "react-relay";
 import Head from "next/head";
+import { useMaybeFragment } from "@wdp/lib/api/hooks";
+import { AppHtmlHeadFragment$key } from "@/relay/AppHtmlHeadFragment.graphql";
 
-export default function AppHtmlHead() {
+export default function AppHtmlHead({ data }: Props) {
+  const app = useMaybeFragment(fragment, data);
+
+  const siteConfig = app?.globalConfiguration.site;
+
+  const title = siteConfig?.installationName || "WDP";
+
+  const summary = siteConfig?.footer.description;
+
   return (
     <Head>
-      <title>WDP</title>
+      <title>{title}</title>
+      <meta name="og:title" content={title} />
+      <meta name="twitter:title" content={title} />
+      {summary && (
+        <>
+          <meta name="og:description" content={summary} />
+          <meta name="twitter:card" content={summary} />
+        </>
+      )}
       <meta
         name="viewport"
         content="minimum-scale=1, initial-scale=1, width=device-width"
@@ -11,3 +30,21 @@ export default function AppHtmlHead() {
     </Head>
   );
 }
+
+interface Props {
+  data?: AppHtmlHeadFragment$key | null;
+}
+
+const fragment = graphql`
+  fragment AppHtmlHeadFragment on Query {
+    globalConfiguration {
+      site {
+        providerName
+        installationName
+        footer {
+          description
+        }
+      }
+    }
+  }
+`;

--- a/packages/frontend/pages/_app.tsx
+++ b/packages/frontend/pages/_app.tsx
@@ -10,7 +10,7 @@ import {
 import { KeycloakRelayProvider, keycloakConfig } from "@wdp/lib/keycloak";
 import { RecordMap } from "relay-runtime/lib/store/RelayStoreTypes";
 import type { Page } from "@wdp/lib/types/page";
-import { AppHtmlHead } from "components/global";
+import Head from "next/head";
 import { updateI18n } from "i18n";
 import { AppContextProvider } from "contexts";
 import { LoadingPage } from "components/atomic";
@@ -61,7 +61,9 @@ function App({
       <SSRKeycloakProvider {...ssrProps}>
         <KeycloakRelayProvider records={records}>
           <AppContextProvider>
-            <AppHtmlHead />
+            <Head>
+              <title>WDP</title>
+            </Head>
             {getLayout({
               PageComponent: Component,
               pageComponentProps: pageProps,

--- a/packages/frontend/pages/index.tsx
+++ b/packages/frontend/pages/index.tsx
@@ -2,16 +2,38 @@ import React from "react";
 import { graphql } from "react-relay";
 import { QueryWrapper } from "@wdp/lib/api/components";
 import { useRouteSlug } from "@wdp/lib/routes";
+import { fetchQuery } from "relay-runtime";
+import { environment } from "@wdp/lib/app";
 import InstanceContentLayout from "components/composed/instance/InstanceContentLayout";
 import { pagesQuery as Query } from "@/relay/pagesQuery.graphql";
-
+import {
+  pagesIndexQuery,
+  pagesIndexQueryResponse,
+} from "@/relay/pagesIndexQuery.graphql";
 import AppLayout from "components/global/AppLayout";
+import { AppHtmlHead } from "components/global";
 
-export default function HomePage() {
+export async function getStaticProps() {
+  const env = environment();
+  const queryProps = await fetchQuery<pagesIndexQuery>(
+    env,
+    indexQuery,
+    {}
+  ).toPromise();
+
+  return {
+    props: {
+      ...queryProps,
+    },
+  };
+}
+
+export default function HomePage(props: pagesIndexQueryResponse) {
   const slug = useRouteSlug();
 
   return (
     <>
+      <AppHtmlHead data={props} />
       <QueryWrapper<Query> query={query} initialVariables={{ slug }}>
         {({ data }) => (
           <AppLayout>
@@ -26,5 +48,17 @@ export default function HomePage() {
 const query = graphql`
   query pagesQuery {
     ...InstanceContentLayoutFragment
+  }
+`;
+
+const indexQuery = graphql`
+  query pagesIndexQuery {
+    globalConfiguration {
+      site {
+        providerName
+        installationName
+      }
+    }
+    ...AppHtmlHeadFragment
   }
 `;

--- a/packages/lib/app/environment.ts
+++ b/packages/lib/app/environment.ts
@@ -13,7 +13,7 @@ interface KeycloakRef {
 }
 
 export default function buildEnvironment(
-  keycloakRef: KeycloakRef,
+  keycloakRef?: KeycloakRef,
   records?: RecordMap
 ) {
   const source = new RecordSource(records);
@@ -27,12 +27,12 @@ export default function buildEnvironment(
     authMiddleware({
       allowEmptyToken: true,
       token: () => {
-        return keycloakRef.current?.token || "";
+        return keycloakRef?.current?.token || "";
       },
       tokenRefreshPromise: async () => {
-        await keycloakRef.current?.updateToken(86400);
+        await keycloakRef?.current?.updateToken(86400);
 
-        return keycloakRef.current?.token || "";
+        return keycloakRef?.current?.token || "";
       },
     }),
   ]);


### PR DESCRIPTION
WIP.
Currently meta tag data is fetched client side. Some services do not wait for javascript to run before getting meta tag data, so the information could be lost. This is a test of getting the data server side using getStaticProps.

Meta tags generated on the homepage:
<img width="591" alt="Screen Shot 2022-05-03 at 12 23 02 PM" src="https://user-images.githubusercontent.com/57107444/166541965-ad1d9220-d403-4cbc-99f1-01d84a0f4615.png">
