### PR TITLE
[B] Fix retry condition in QueryWrapper

### DIFF
--- a/packages/admin/components/composed/collection/CollectionList/CollectionList.tsx
+++ b/packages/admin/components/composed/collection/CollectionList/CollectionList.tsx
@@ -3,6 +3,7 @@ import { OperationType } from "relay-runtime";
 import { graphql } from "react-relay";
 import type { ModelTableActionProps } from "react-table";
 import { useTranslation } from "react-i18next";
+import { useLatestPresentValue } from "@wdp/lib/hooks";
 import ModelListPage from "components/composed/model/ModelListPage";
 import {
   useDestroyer,
@@ -40,10 +41,14 @@ function CollectionList<T extends OperationType>({
     data
   );
 
+  const { current: memoizedData } = useLatestPresentValue(collections);
+
   const searchScope = useMaybeFragment<CollectionListSearchFragment$key>(
     searchFragment,
     searchData
   );
+
+  const { current: memoizedSearch } = useLatestPresentValue(searchScope);
 
   const searchQuery = useSearchQueryVars();
 
@@ -101,10 +106,10 @@ function CollectionList<T extends OperationType>({
       data={
         searchQuery.query ||
         (searchQuery.predicates && searchQuery.predicates.length > 0)
-          ? searchScope?.results
-          : collections
+          ? memoizedSearch?.results
+          : memoizedData
       }
-      searchData={searchScope}
+      searchData={memoizedSearch}
       headerStyle={headerStyle}
       hideHeader={hideHeader}
       viewOptions={ALL_VIEW_OPTIONS}

--- a/packages/admin/components/composed/file/FileCreateModal/FileCreateModal.tsx
+++ b/packages/admin/components/composed/file/FileCreateModal/FileCreateModal.tsx
@@ -3,14 +3,18 @@ import { useTranslation } from "react-i18next";
 import type { DialogState } from "reakit/Dialog";
 import { graphql } from "react-relay";
 import { QueryWrapper } from "@wdp/lib/api/components";
+import routeQueryArrayToString from "@wdp/lib/routes/helpers/routeQueryArrayToString";
+import { useRouter } from "next/router";
 import Modal from "components/layout/Modal";
 import FileCreateForm from "components/composed/file/FileCreateForm";
 import type { FileCreateModalQuery as Query } from "__generated__/FileCreateModalQuery.graphql";
-import { useRouteSlug } from "hooks";
 
 const FileCreateModal = ({ dialog }: Props) => {
   const { t } = useTranslation();
-  const slug = useRouteSlug();
+  const router = useRouter();
+  const { slug: slugQ, drawerSlug: drawerSlugQ } = router.query;
+  const slug = routeQueryArrayToString(slugQ);
+  const drawerSlug = routeQueryArrayToString(drawerSlugQ);
 
   return (
     <Modal
@@ -21,7 +25,7 @@ const FileCreateModal = ({ dialog }: Props) => {
       {({ handleClose }) => (
         <QueryWrapper<Query>
           query={query}
-          initialVariables={{ slug: slug || "" }}
+          initialVariables={{ slug: slug || drawerSlug || "" }}
         >
           {({ data }) => (
             <FileCreateForm

--- a/packages/admin/components/composed/item/ItemList/ItemList.tsx
+++ b/packages/admin/components/composed/item/ItemList/ItemList.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type { OperationType } from "relay-runtime";
 import { graphql } from "react-relay";
 import type { ModelTableActionProps } from "react-table";
+import { useLatestPresentValue } from "@wdp/lib/hooks";
 import {
   useMaybeFragment,
   useDestroyer,
@@ -31,10 +32,14 @@ function ItemList<T extends OperationType>({
 }: ItemListProps) {
   const items = useMaybeFragment<ItemListFragment$key>(fragment, data);
 
+  const { current: memoizedData } = useLatestPresentValue(items);
+
   const searchScope = useMaybeFragment<ItemListSearchFragment$key>(
     searchFragment,
     searchData
   );
+
+  const { current: memoizedSearch } = useLatestPresentValue(searchScope);
 
   const destroy = useDestroyer();
 
@@ -88,10 +93,10 @@ function ItemList<T extends OperationType>({
       data={
         searchQuery.query ||
         (searchQuery.predicates && searchQuery.predicates.length > 0)
-          ? searchScope?.results
-          : items
+          ? memoizedSearch?.results
+          : memoizedData
       }
-      searchData={searchScope}
+      searchData={memoizedSearch}
       headerStyle={headerStyle}
       hideHeader={hideHeader}
       viewOptions={ALL_VIEW_OPTIONS}

--- a/packages/lib/api/components/QueryWrapper.tsx
+++ b/packages/lib/api/components/QueryWrapper.tsx
@@ -11,10 +11,10 @@ export default function QueryWrapper<T extends OperationType>(props: Props<T>) {
 
   const { variables, setVariables } = useManagedVariables<T>(initialVariables);
 
-  useEffect(() => initialVariables && setVariables(initialVariables), [
-    initialVariables,
-    setVariables,
-  ]);
+  useEffect(
+    () => initialVariables && setVariables(initialVariables),
+    [initialVariables, setVariables]
+  );
 
   const { data, error, isLoading, retry } = useAuthenticatedQuery<T>(
     query,
@@ -27,7 +27,7 @@ export default function QueryWrapper<T extends OperationType>(props: Props<T>) {
   // If the global refetch tags changed, let's refetch the data. See MutationForm for
   // the other side of this mechanism.
   useEffect(() => {
-    if (!intersection(refetchTags, triggeredRefetchTags)) return;
+    if (!intersection(refetchTags, triggeredRefetchTags).length) return;
     retry();
   }, [triggeredRefetchTags, refetchTags, retry]);
 


### PR DESCRIPTION
The answer to why opening drawers in admin reloaded the underlying content turned out to be a bug in the refetch logic in `QueryWrapper`:
```
useEffect(() => {
    if (!intersection(refetchTags, triggeredRefetchTags)) return;
    retry();
  }, [triggeredRefetchTags, refetchTags, retry]);
```
`!intersection(refetchTags, triggeredRefetchTags)` returns an empty array if there are no matches, so this condition was always true.

Also resolves:
- WDP-800