### PR TITLE
[B] Fix body scroll lock for drawers

### DIFF
--- a/packages/admin/components/layout/Drawer/Drawer.styles.ts
+++ b/packages/admin/components/layout/Drawer/Drawer.styles.ts
@@ -28,6 +28,10 @@ export const DialogBackdrop = styled(BaseDialogBackdrop)`
   &[data-enter] {
     opacity: 1;
   }
+
+  &[data-leave] {
+    opacity: 0;
+  }
 `;
 
 export const Dialog = styled(BaseDialog)`

--- a/packages/admin/components/layout/Drawer/Drawer.tsx
+++ b/packages/admin/components/layout/Drawer/Drawer.tsx
@@ -7,6 +7,7 @@ import * as Styled from "./Drawer.styles";
 import { ButtonControl } from "components/atomic/buttons/";
 import { useQueryStateContext } from "hooks";
 import LoadingCircle from "components/atomic/loading/LoadingCircle";
+import usePreventBodyScroll from "components/layout/Modal/hooks/usePreventBodyScroll";
 
 /**
  * A drawer for complex actions, forms.
@@ -31,12 +32,15 @@ const Drawer = ({
     if (onClose) onClose();
   };
 
+  usePreventBodyScroll(dialog.visible);
+
   return (
     <Styled.DialogBackdrop {...dialog}>
       <Styled.Dialog
         aria-labelledby={uidLabel}
         aria-describedby={uidDesc}
         hideOnClickOutside={hideOnClickOutside}
+        preventBodyScroll={false}
         {...dialog}
       >
         <Styled.Header>

--- a/packages/admin/components/layout/Modal/hooks/usePreventBodyScroll.ts
+++ b/packages/admin/components/layout/Modal/hooks/usePreventBodyScroll.ts
@@ -1,13 +1,17 @@
 /* This hook is based on and significantly borrows from the fix Reakit is implementing for their v2 release. See: https://github.com/ariakit/ariakit/pull/1271/files  */
 
-import { useLayoutEffect, useEffect } from "react";
+import { useLayoutEffect, useEffect, useRef } from "react";
 
 export default function usePreventBodyScroll(visible = false) {
   const isBrowser =
     typeof window !== "undefined" && !!window.document?.createElement;
   const safeEffect = isBrowser ? useLayoutEffect : useEffect;
 
+  const prevVisible = useRef(visible);
+
   safeEffect(() => {
+    if (prevVisible.current === visible) return;
+
     const { documentElement, body } = document;
 
     /* eslint-disable-next-line  @typescript-eslint/no-empty-function */
@@ -24,6 +28,7 @@ export default function usePreventBodyScroll(visible = false) {
 
     if (visible) {
       Object.assign(body.style, modalVisibleStyle);
+      prevVisible.current = true;
     }
 
     return () => (body.style.cssText = baseStyle);


### PR DESCRIPTION
@jen-castiron I think this works, but it could definitely use another set of 👀 before merging. As I mentioned in Linear, even if this works, I think we could further improve performance of lists with lots of dialog components. It seems like body styles get set too many times by the various dialogs.