### PR TITLE
[F] Fix bug with parent selector breaking on schema error

### DIFF
--- a/packages/admin/__generated__/AppContextProviderQuery.graphql.ts
+++ b/packages/admin/__generated__/AppContextProviderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8e315dbc053c44ca1af9ef78746e32a2>>
+ * @generated SignedSource<<272773da6a1fcf3853b58657616486da>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -85,6 +85,13 @@ v8 = {
   "args": null,
   "kind": "ScalarField",
   "name": "kind",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
   "storageKey": null
 };
 return {
@@ -250,24 +257,6 @@ return {
             ],
             "storageKey": null
           },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "EntitiesSettings",
-            "kind": "LinkedField",
-            "name": "entities",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "suppressExternalLinks",
-                "storageKey": null
-              }
-            ],
-            "storageKey": null
-          },
           (v6/*: any*/)
         ],
         "storageKey": null
@@ -326,18 +315,25 @@ return {
                     "storageKey": null
                   },
                   (v8/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "slug",
-                    "storageKey": null
-                  },
+                  (v9/*: any*/),
                   {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
                     "name": "number",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "SchemaDefinition",
+                    "kind": "LinkedField",
+                    "name": "schemaDefinition",
+                    "plural": false,
+                    "selections": [
+                      (v9/*: any*/),
+                      (v6/*: any*/)
+                    ],
                     "storageKey": null
                   },
                   (v6/*: any*/)
@@ -429,12 +425,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "5e940169cbdb9f5bd1bb7f7f84c49ae0",
+    "cacheID": "b8e16ce588e9a4468a3adb3ec233da48",
     "id": null,
     "metadata": {},
     "name": "AppContextProviderQuery",
     "operationKind": "query",
-    "text": "query AppContextProviderQuery {\n  ...GlobalContextFragment\n  ...ViewerContextFragment\n}\n\nfragment AvatarFragment on ImageAttachment {\n  storage\n  small {\n    webp {\n      ...ImageFragment\n    }\n  }\n}\n\nfragment FooterFragment on GlobalConfiguration {\n  site {\n    footer {\n      copyrightStatement\n      description\n    }\n  }\n}\n\nfragment GlobalContextFragment on Query {\n  globalConfiguration {\n    ...ProviderBarFragment\n    ...InstallationNameFragment\n    ...UnauthorizedMessageFragment\n    ...FooterFragment\n    ...InstallationLogoFragment\n    entities {\n      suppressExternalLinks\n    }\n    id\n  }\n  ...SchemaSelectorSchemasFragment\n}\n\nfragment ImageFragment on Image {\n  __isImage: __typename\n  alt\n  url\n  width\n  height\n}\n\nfragment InstallationLogoFragment on GlobalConfiguration {\n  site {\n    installationName\n    logoMode\n  }\n  logo {\n    storage\n    original {\n      originalFilename\n      ...ImageFragment\n    }\n    sansText {\n      size\n      webp {\n        width\n        height\n        ...ImageFragment\n      }\n    }\n  }\n}\n\nfragment InstallationNameFragment on GlobalConfiguration {\n  site {\n    installationName\n  }\n}\n\nfragment ProviderBarFragment on GlobalConfiguration {\n  site {\n    providerName\n  }\n}\n\nfragment SchemaSelectorModalOptionsFragment on SchemaVersionConnection {\n  edges {\n    node {\n      name\n      namespace\n      identifier\n      kind\n      slug\n      number\n      id\n    }\n  }\n}\n\nfragment SchemaSelectorSchemasFragment on Query {\n  schemaVersions {\n    nodes {\n      name\n      kind\n      id\n    }\n    ...SchemaSelectorModalOptionsFragment\n  }\n}\n\nfragment UnauthorizedMessageFragment on GlobalConfiguration {\n  site {\n    providerName\n  }\n}\n\nfragment ViewerContextFragment on Query {\n  viewer {\n    name\n    allowedActions\n    uploadAccess\n    uploadToken\n    avatar {\n      ...AvatarFragment\n    }\n    globalAdmin\n    id\n  }\n}\n"
+    "text": "query AppContextProviderQuery {\n  ...GlobalContextFragment\n  ...ViewerContextFragment\n}\n\nfragment AvatarFragment on ImageAttachment {\n  storage\n  small {\n    webp {\n      ...ImageFragment\n    }\n  }\n}\n\nfragment FooterFragment on GlobalConfiguration {\n  site {\n    footer {\n      copyrightStatement\n      description\n    }\n  }\n}\n\nfragment GlobalContextFragment on Query {\n  globalConfiguration {\n    ...ProviderBarFragment\n    ...InstallationNameFragment\n    ...UnauthorizedMessageFragment\n    ...FooterFragment\n    ...InstallationLogoFragment\n    id\n  }\n  ...SchemaSelectorSchemasFragment\n}\n\nfragment ImageFragment on Image {\n  __isImage: __typename\n  alt\n  url\n  width\n  height\n}\n\nfragment InstallationLogoFragment on GlobalConfiguration {\n  site {\n    installationName\n    logoMode\n  }\n  logo {\n    storage\n    original {\n      originalFilename\n      ...ImageFragment\n    }\n    sansText {\n      size\n      webp {\n        width\n        height\n        ...ImageFragment\n      }\n    }\n  }\n}\n\nfragment InstallationNameFragment on GlobalConfiguration {\n  site {\n    installationName\n  }\n}\n\nfragment ProviderBarFragment on GlobalConfiguration {\n  site {\n    providerName\n  }\n}\n\nfragment SchemaSelectorModalOptionsFragment on SchemaVersionConnection {\n  edges {\n    node {\n      name\n      namespace\n      identifier\n      kind\n      slug\n      number\n      schemaDefinition {\n        slug\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment SchemaSelectorSchemasFragment on Query {\n  schemaVersions {\n    nodes {\n      name\n      kind\n      id\n    }\n    ...SchemaSelectorModalOptionsFragment\n  }\n}\n\nfragment UnauthorizedMessageFragment on GlobalConfiguration {\n  site {\n    providerName\n  }\n}\n\nfragment ViewerContextFragment on Query {\n  viewer {\n    name\n    allowedActions\n    uploadAccess\n    uploadToken\n    avatar {\n      ...AvatarFragment\n    }\n    globalAdmin\n    id\n  }\n}\n"
   }
 };
 })();

--- a/packages/admin/__generated__/CollectionAddDrawerQuery.graphql.ts
+++ b/packages/admin/__generated__/CollectionAddDrawerQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4a46de499677e20d37d3dc310cd9083b>>
+ * @generated SignedSource<<73949155dacad761f352130432495804>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -132,6 +132,25 @@ return {
             "kind": "ScalarField",
             "name": "value",
             "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "SchemaDefinition",
+            "kind": "LinkedField",
+            "name": "schemaDefinition",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "slug",
+                "storageKey": null
+              },
+              (v2/*: any*/)
+            ],
+            "storageKey": null
           }
         ],
         "storageKey": null
@@ -180,12 +199,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ff40218c6fe9061a23bcb28d75b0ccbe",
+    "cacheID": "f538eaca380ea3e3597b7e36bc866476",
     "id": null,
     "metadata": {},
     "name": "CollectionAddDrawerQuery",
     "operationKind": "query",
-    "text": "query CollectionAddDrawerQuery(\n  $parentSlug: Slug!\n  $schemaKind: SchemaKind!\n) {\n  collection(slug: $parentSlug) {\n    id\n  }\n  community(slug: $parentSlug) {\n    id\n  }\n  ...CollectionAddFormFragment\n}\n\nfragment CollectionAddFormFragment on Query {\n  ...SchemaSelectFragment\n  ...CommunitySelectFragment\n}\n\nfragment CommunitySelectFragment on Query {\n  communities {\n    edges {\n      node {\n        id\n        name\n      }\n    }\n  }\n}\n\nfragment SchemaSelectFragment on Query {\n  schemaVersionOptions(kind: $schemaKind) {\n    label\n    value\n  }\n}\n"
+    "text": "query CollectionAddDrawerQuery(\n  $parentSlug: Slug!\n  $schemaKind: SchemaKind!\n) {\n  collection(slug: $parentSlug) {\n    id\n  }\n  community(slug: $parentSlug) {\n    id\n  }\n  ...CollectionAddFormFragment\n}\n\nfragment CollectionAddFormFragment on Query {\n  ...SchemaSelectFragment\n  ...CommunitySelectFragment\n}\n\nfragment CommunitySelectFragment on Query {\n  communities {\n    edges {\n      node {\n        id\n        name\n      }\n    }\n  }\n}\n\nfragment SchemaSelectFragment on Query {\n  schemaVersionOptions(kind: $schemaKind) {\n    label\n    value\n    schemaDefinition {\n      slug\n      id\n    }\n  }\n}\n"
   }
 };
 })();

--- a/packages/admin/__generated__/CollectionAddDrawerRootQuery.graphql.ts
+++ b/packages/admin/__generated__/CollectionAddDrawerRootQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<af1e60d9af7a2513048642acf9848d7d>>
+ * @generated SignedSource<<a69bb14bf04d5c93d4634c2b2e8bfd56>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -29,7 +29,14 @@ var v0 = [
     "kind": "LocalArgument",
     "name": "schemaKind"
   }
-];
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -79,6 +86,25 @@ return {
             "kind": "ScalarField",
             "name": "value",
             "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "SchemaDefinition",
+            "kind": "LinkedField",
+            "name": "schemaDefinition",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "slug",
+                "storageKey": null
+              },
+              (v1/*: any*/)
+            ],
+            "storageKey": null
           }
         ],
         "storageKey": null
@@ -107,13 +133,7 @@ return {
                 "name": "node",
                 "plural": false,
                 "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "id",
-                    "storageKey": null
-                  },
+                  (v1/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -133,12 +153,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a0262bffd549e448765735e09364363d",
+    "cacheID": "de3fb5a1ca30d54ad4c694ca5f73cb45",
     "id": null,
     "metadata": {},
     "name": "CollectionAddDrawerRootQuery",
     "operationKind": "query",
-    "text": "query CollectionAddDrawerRootQuery(\n  $schemaKind: SchemaKind!\n) {\n  ...CollectionAddFormFragment\n}\n\nfragment CollectionAddFormFragment on Query {\n  ...SchemaSelectFragment\n  ...CommunitySelectFragment\n}\n\nfragment CommunitySelectFragment on Query {\n  communities {\n    edges {\n      node {\n        id\n        name\n      }\n    }\n  }\n}\n\nfragment SchemaSelectFragment on Query {\n  schemaVersionOptions(kind: $schemaKind) {\n    label\n    value\n  }\n}\n"
+    "text": "query CollectionAddDrawerRootQuery(\n  $schemaKind: SchemaKind!\n) {\n  ...CollectionAddFormFragment\n}\n\nfragment CollectionAddFormFragment on Query {\n  ...SchemaSelectFragment\n  ...CommunitySelectFragment\n}\n\nfragment CommunitySelectFragment on Query {\n  communities {\n    edges {\n      node {\n        id\n        name\n      }\n    }\n  }\n}\n\nfragment SchemaSelectFragment on Query {\n  schemaVersionOptions(kind: $schemaKind) {\n    label\n    value\n    schemaDefinition {\n      slug\n      id\n    }\n  }\n}\n"
   }
 };
 })();

--- a/packages/admin/__generated__/GlobalContextFragment.graphql.ts
+++ b/packages/admin/__generated__/GlobalContextFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1ccca43914a578c967d97cdff3f411fe>>
+ * @generated SignedSource<<e05541fed40c18270bb6b20f42367441>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,9 +12,6 @@ import { Fragment, ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type GlobalContextFragment$data = {
   readonly globalConfiguration: {
-    readonly entities: {
-      readonly suppressExternalLinks: boolean;
-    };
     readonly " $fragmentSpreads": FragmentRefs<"FooterFragment" | "InstallationLogoFragment" | "InstallationNameFragment" | "ProviderBarFragment" | "UnauthorizedMessageFragment">;
   };
   readonly " $fragmentSpreads": FragmentRefs<"SchemaSelectorSchemasFragment">;
@@ -63,24 +60,6 @@ const node: ReaderFragment = {
           "args": null,
           "kind": "FragmentSpread",
           "name": "InstallationLogoFragment"
-        },
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "EntitiesSettings",
-          "kind": "LinkedField",
-          "name": "entities",
-          "plural": false,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "suppressExternalLinks",
-              "storageKey": null
-            }
-          ],
-          "storageKey": null
         }
       ],
       "storageKey": null
@@ -139,6 +118,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "d0abf95579813da70bb902ee84942c80";
+(node as any).hash = "cf89f641e87bc805a335858cd96e6976";
 
 export default node;

--- a/packages/admin/__generated__/ItemAddDrawerQuery.graphql.ts
+++ b/packages/admin/__generated__/ItemAddDrawerQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<518701f05b598a2338c8c9b88b196383>>
+ * @generated SignedSource<<8b5bb8cbb1e1d7d7e54035d46df37087>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -36,21 +36,22 @@ var v0 = [
     "name": "schemaKind"
   }
 ],
-v1 = [
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = [
   {
     "kind": "Variable",
     "name": "slug",
     "variableName": "entitySlug"
   }
 ],
-v2 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "id",
-    "storageKey": null
-  }
+v3 = [
+  (v1/*: any*/)
 ];
 return {
   "fragment": {
@@ -101,39 +102,58 @@ return {
             "kind": "ScalarField",
             "name": "value",
             "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "SchemaDefinition",
+            "kind": "LinkedField",
+            "name": "schemaDefinition",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "slug",
+                "storageKey": null
+              },
+              (v1/*: any*/)
+            ],
+            "storageKey": null
           }
         ],
         "storageKey": null
       },
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v2/*: any*/),
         "concreteType": "Item",
         "kind": "LinkedField",
         "name": "item",
         "plural": false,
-        "selections": (v2/*: any*/),
+        "selections": (v3/*: any*/),
         "storageKey": null
       },
       {
         "alias": null,
-        "args": (v1/*: any*/),
+        "args": (v2/*: any*/),
         "concreteType": "Collection",
         "kind": "LinkedField",
         "name": "collection",
         "plural": false,
-        "selections": (v2/*: any*/),
+        "selections": (v3/*: any*/),
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "ab1189109bc16bd37378f0195d822811",
+    "cacheID": "aad0825f9810d677aa409982f35e939e",
     "id": null,
     "metadata": {},
     "name": "ItemAddDrawerQuery",
     "operationKind": "query",
-    "text": "query ItemAddDrawerQuery(\n  $entitySlug: Slug!\n  $schemaKind: SchemaKind!\n) {\n  ...ItemAddFormFragment\n}\n\nfragment ItemAddFormFragment on Query {\n  ...SchemaSelectFragment\n  item(slug: $entitySlug) {\n    id\n  }\n  collection(slug: $entitySlug) {\n    id\n  }\n}\n\nfragment SchemaSelectFragment on Query {\n  schemaVersionOptions(kind: $schemaKind) {\n    label\n    value\n  }\n}\n"
+    "text": "query ItemAddDrawerQuery(\n  $entitySlug: Slug!\n  $schemaKind: SchemaKind!\n) {\n  ...ItemAddFormFragment\n}\n\nfragment ItemAddFormFragment on Query {\n  ...SchemaSelectFragment\n  item(slug: $entitySlug) {\n    id\n  }\n  collection(slug: $entitySlug) {\n    id\n  }\n}\n\nfragment SchemaSelectFragment on Query {\n  schemaVersionOptions(kind: $schemaKind) {\n    label\n    value\n    schemaDefinition {\n      slug\n      id\n    }\n  }\n}\n"
   }
 };
 })();

--- a/packages/admin/__generated__/SchemaSelectFragment.graphql.ts
+++ b/packages/admin/__generated__/SchemaSelectFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<39bc955b7a8eeead758bed63cc56c469>>
+ * @generated SignedSource<<d3e27e67c95f3e309593d09e7c5b135f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,6 +13,9 @@ import { FragmentRefs } from "relay-runtime";
 export type SchemaSelectFragment$data = {
   readonly schemaVersionOptions: ReadonlyArray<{
     readonly label: string;
+    readonly schemaDefinition: {
+      readonly slug: string;
+    };
     readonly value: string;
   }>;
   readonly " $fragmentType": "SchemaSelectFragment";
@@ -60,6 +63,24 @@ const node: ReaderFragment = {
           "kind": "ScalarField",
           "name": "value",
           "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "SchemaDefinition",
+          "kind": "LinkedField",
+          "name": "schemaDefinition",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "slug",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
         }
       ],
       "storageKey": null
@@ -69,6 +90,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "f82da6bde36b4909bd5787dcbfb19439";
+(node as any).hash = "98aa1b8330db2b49515a734792160574";
 
 export default node;

--- a/packages/admin/__generated__/SchemaSelectorModalOptionsFragment.graphql.ts
+++ b/packages/admin/__generated__/SchemaSelectorModalOptionsFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1a6b915f7d9b8bc8ed366b64f4e0ce6f>>
+ * @generated SignedSource<<1bddcb0ace47fdbd902583bfa54b3f9e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -19,6 +19,9 @@ export type SchemaSelectorModalOptionsFragment$data = {
       readonly name: string;
       readonly namespace: string;
       readonly number: string;
+      readonly schemaDefinition: {
+        readonly slug: string;
+      };
       readonly slug: string;
     };
   }>;
@@ -29,7 +32,15 @@ export type SchemaSelectorModalOptionsFragment$key = {
   readonly " $fragmentSpreads": FragmentRefs<"SchemaSelectorModalOptionsFragment">;
 };
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+};
+return {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
@@ -79,18 +90,24 @@ const node: ReaderFragment = {
               "name": "kind",
               "storageKey": null
             },
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "slug",
-              "storageKey": null
-            },
+            (v0/*: any*/),
             {
               "alias": null,
               "args": null,
               "kind": "ScalarField",
               "name": "number",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "SchemaDefinition",
+              "kind": "LinkedField",
+              "name": "schemaDefinition",
+              "plural": false,
+              "selections": [
+                (v0/*: any*/)
+              ],
               "storageKey": null
             }
           ],
@@ -103,7 +120,8 @@ const node: ReaderFragment = {
   "type": "SchemaVersionConnection",
   "abstractKey": null
 };
+})();
 
-(node as any).hash = "a1d8ededc84a8d4c6a451f2dedab1bdd";
+(node as any).hash = "fa39c6b24de2bd45f37f395a1b9d5993";
 
 export default node;

--- a/packages/admin/components/api/MutationForm/MutationForm.tsx
+++ b/packages/admin/components/api/MutationForm/MutationForm.tsx
@@ -174,7 +174,6 @@ export default function MutationForm<
         const nameKeys = Object.keys(form.getValues());
 
         for (const { path, error } of errors.attributes) {
-          // TODO: Add other errors to the UI for reference
           if (nameKeys.includes(path)) {
             form.setError(path, error, { shouldFocus: false });
           }
@@ -202,7 +201,6 @@ export default function MutationForm<
       onSaveAndClose,
       notify,
       t,
-      dispatch,
       failureNotification,
       onFailure,
       form,

--- a/packages/admin/components/api/MutationForm/MutationForm.tsx
+++ b/packages/admin/components/api/MutationForm/MutationForm.tsx
@@ -8,6 +8,7 @@ import has from "lodash/has";
 import { ContentHeader } from "components/layout";
 import { Button } from "components/atomic";
 import { useNotify, usePageContext } from "hooks";
+
 import GlobalErrors from "./GlobalErrors";
 
 import useMutationFormState from "./useMutationFormState";
@@ -82,9 +83,9 @@ export default function MutationForm<
 
   const form = useForm<T>({
     criteriaMode: "all",
+    shouldFocusError: true,
     defaultValues,
   });
-
   const [state, dispatch] = useMutationFormState<M, T>({ form, name });
 
   const [mutate, loading] = useMutation<M>(props.mutation);
@@ -126,8 +127,6 @@ export default function MutationForm<
     },
     [getErrors, name],
   );
-
-  const { setError } = form;
 
   const handleResponse = useCallback(
     (
@@ -172,8 +171,13 @@ export default function MutationForm<
         /* eslint-disable no-console */
         console.dir({ errors });
 
+        const nameKeys = Object.keys(form.getValues());
+
         for (const { path, error } of errors.attributes) {
-          setError(path, error, { shouldFocus: false });
+          // TODO: Add other errors to the UI for reference
+          if (nameKeys.includes(path)) {
+            form.setError(path, error, { shouldFocus: false });
+          }
         }
 
         if (typeof onFailure === "function") {
@@ -182,7 +186,7 @@ export default function MutationForm<
             response,
             variables,
             values,
-            setError,
+            setError: form.setError,
           });
         }
       }
@@ -190,17 +194,18 @@ export default function MutationForm<
     [
       extractErrorsRef,
       isSuccess,
-      onFailure,
+      dispatch,
+      successNotification,
+      setTriggeredRefetchTags,
+      refetchTags,
       onSuccess,
       onSaveAndClose,
-      setError,
-      failureNotification,
       notify,
-      refetchTags,
-      setTriggeredRefetchTags,
-      successNotification,
       t,
       dispatch,
+      failureNotification,
+      onFailure,
+      form,
     ],
   );
 
@@ -219,23 +224,20 @@ export default function MutationForm<
         onError: (err) => dispatch({ type: "error", serverError: err }),
       });
     },
-    [castVariables, dispatch, mutate, handleResponse],
+    [castVariables, dispatch, handleResponse, mutate],
   );
 
-  const { handleSubmit } = form;
-
   /* eslint-disable prettier/prettier */
-  const onSubmit = useMemo(() => handleSubmit(submitHandler), [
-    handleSubmit,
-    submitHandler,
-  ]);
+  const onSubmit = useMemo(() => form.handleSubmit(submitHandler), [form, submitHandler]);
   /* eslint-enable prettier/prettier */
 
-  const {
-    formState: { isSubmitting, isValidating },
-  } = form;
+  const submitDisabled = useMemo(() => {
+    const {
+      formState: { isSubmitting, isValidating },
+    } = form;
 
-  const submitDisabled = loading || isSubmitting || isValidating;
+    return loading || isSubmitting || isValidating;
+  }, [form, loading]);
 
   return (
     <FormProvider {...form}>

--- a/packages/admin/components/api/MutationForm/useMutationFormState.ts
+++ b/packages/admin/components/api/MutationForm/useMutationFormState.ts
@@ -43,12 +43,12 @@ function reducer<
         response: action.response,
       };
     case "failure": {
-      const { global: globalErrors } = action.errors;
+      const { global: globalErrors, user: userErrors } = action.errors;
 
       return {
         ...state,
         status: "failure",
-        globalErrors,
+        globalErrors: [...globalErrors, ...userErrors],
       };
     }
     case "error": {

--- a/packages/admin/components/api/SchemaFormFields/SchemaFormFields.tsx
+++ b/packages/admin/components/api/SchemaFormFields/SchemaFormFields.tsx
@@ -11,6 +11,7 @@ export default function SchemaFormFields({
   title = "forms.schema.label",
   data,
   schemaKind,
+  schemaSlugs,
 }: Props) {
   const instance = useFragment(fragment, data);
 
@@ -21,7 +22,11 @@ export default function SchemaFormFields({
       <ContentHeader title={t(title)} headerStyle="secondary" />
       {instance.properties && instance.properties.length > 0 ? (
         <>
-          <SchemaSelector schemaData={instance} schemaKind={schemaKind} />
+          <SchemaSelector
+            schemaData={instance}
+            schemaKind={schemaKind}
+            schemaSlugs={schemaSlugs}
+          />
           <FormGrid>
             {instance.properties.map((prop, index) => (
               <Property property={prop} key={index} />
@@ -29,7 +34,11 @@ export default function SchemaFormFields({
           </FormGrid>
         </>
       ) : (
-        <SchemaSelector schemaData={instance} schemaKind={schemaKind} />
+        <SchemaSelector
+          schemaData={instance}
+          schemaKind={schemaKind}
+          schemaSlugs={schemaSlugs}
+        />
       )}
     </SchemaFormFieldsContextProvider>
   );
@@ -39,6 +48,8 @@ interface Props {
   data: SchemaFormFieldsFragment$key;
   title?: string;
   schemaKind: "COLLECTION" | "ITEM" | "COMMUNITY";
+  // Filter options by these schema slugs
+  schemaSlugs?: string[];
 }
 
 const fragment = graphql`

--- a/packages/admin/components/composed/collection/CollectionAddForm/CollectionAddForm.tsx
+++ b/packages/admin/components/composed/collection/CollectionAddForm/CollectionAddForm.tsx
@@ -17,7 +17,7 @@ import type {
   CollectionAddFormMutation,
 } from "@/relay/CollectionAddFormMutation.graphql";
 
-export default function AddCollectionForm({
+export default function CollectionAddForm({
   onSuccess,
   onCancel,
   data,

--- a/packages/admin/components/forms/SchemaSelector/SchemaSelector.tsx
+++ b/packages/admin/components/forms/SchemaSelector/SchemaSelector.tsx
@@ -18,7 +18,7 @@ import * as Styled from "./SchemaSelector.styles";
 
 type SelectProps = React.ComponentProps<typeof Select>;
 
-const SchemaSelector = ({ schemaData, schemaKind }: Props) => {
+const SchemaSelector = ({ schemaData, schemaKind, schemaSlugs }: Props) => {
   const data = useMaybeFragment(fragment as GraphQLTaggedNode, schemaData);
 
   const dialog = useDialogState({ visible: false, animated: true });
@@ -63,6 +63,7 @@ const SchemaSelector = ({ schemaData, schemaKind }: Props) => {
           entityId={data?.entityId}
           schemaVersionSlug={data?.schemaVersion?.slug}
           schemaKind={schemaKind}
+          schemaSlugs={schemaSlugs}
         />
       </Portal>
     </>
@@ -72,6 +73,8 @@ const SchemaSelector = ({ schemaData, schemaKind }: Props) => {
 interface Props extends Pick<SelectProps, "defaultValue"> {
   schemaData?: SchemaSelectorDataFragment$key;
   schemaKind: "COLLECTION" | "ITEM" | "COMMUNITY";
+  // Filter by these schema slugs
+  schemaSlugs?: string[];
 }
 
 export default SchemaSelector;

--- a/packages/admin/components/forms/SchemaSelector/SchemaSelectorModal.tsx
+++ b/packages/admin/components/forms/SchemaSelector/SchemaSelectorModal.tsx
@@ -23,6 +23,7 @@ const SchemaSelectorModal = ({
   entityId,
   schemaVersionSlug,
   schemaKind,
+  schemaSlugs,
 }: Props) => {
   const { t } = useTranslation();
 
@@ -41,7 +42,13 @@ const SchemaSelectorModal = ({
 
   const options =
     schemaVersions?.edges
-      ?.filter((item) => item.node.kind === schemaKind)
+      ?.filter(
+        (item) =>
+          item.node.kind === schemaKind &&
+          (schemaSlugs && schemaSlugs.length > 0
+            ? schemaSlugs.includes(item.node.schemaDefinition.slug)
+            : true),
+      )
       .map((item) => ({
         label: `${item.node.name} ${item.node.number}`,
         value: item.node.slug,
@@ -50,7 +57,7 @@ const SchemaSelectorModal = ({
   const renderForm = useRenderForm<Fields>(
     ({ form: { register } }) => (
       <Forms.Select
-        options={options}
+        options={[{ label: "Select an option", value: "" }, ...options]}
         label={t("forms.schema.new_label")}
         description={t("forms.schema.change_warning")}
         {...register("schemaVersionSlug")}
@@ -96,6 +103,8 @@ interface Props {
   entityId: string;
   schemaVersionSlug: string;
   schemaKind: SchemaKind;
+  // Filter by these schema slugs
+  schemaSlugs?: string[];
 }
 
 const fragment = graphql`
@@ -108,6 +117,9 @@ const fragment = graphql`
         kind
         slug
         number
+        schemaDefinition {
+          slug
+        }
       }
     }
   }


### PR DESCRIPTION
This PR updates MutationForm to filter out errors that are not paired with a field. When errors are added to react-hook-form, they're cleared _if_ they can be matched with a input field. If there's no matching input field, then the form will remain in an error state indefinitely. 

This PR also adds `user` errors to the global errors displayed on a form. Some of these errors display important information on why a form didn't save, but they're not included in either global or attribute error lists.