### PR TITLE
[C] Fix styled component DOM warnings, errors

### DIFF
--- a/packages/admin/components/api/MutationForm/MutationForm.tsx
+++ b/packages/admin/components/api/MutationForm/MutationForm.tsx
@@ -283,7 +283,7 @@ export default function MutationForm<
               type="button"
               disabled={submitDisabled}
               onClick={onCancel}
-              secondary
+              $secondary
             >
               {t("common.cancel")}
             </Button>

--- a/packages/admin/components/api/NullForm/NullForm.tsx
+++ b/packages/admin/components/api/NullForm/NullForm.tsx
@@ -76,12 +76,12 @@ export default function NullForm<T extends FieldValues = FieldValues>({
               disabled={isSubmitting}
               onClick={onReset}
               type="reset"
-              secondary
+              $secondary
             >
               {t(resetLabel || "common.reset")}
             </Button>
           )}
-          <Button type="button" secondary onClick={onCancelCallback}>
+          <Button type="button" $secondary onClick={onCancelCallback}>
             {t("common.cancel")}
           </Button>
         </div>

--- a/packages/admin/components/api/SchemaInstanceForm/Actions.tsx
+++ b/packages/admin/components/api/SchemaInstanceForm/Actions.tsx
@@ -31,7 +31,7 @@ export default function Actions({ onCancel, onSaveAndClose }: Props) {
           type="button"
           disabled={submitDisabled}
           onClick={onCancel}
-          secondary
+          $secondary
         >
           {t("common.cancel")}
         </Button>

--- a/packages/admin/components/atomic/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/admin/components/atomic/Breadcrumbs/Breadcrumbs.tsx
@@ -8,6 +8,7 @@ type LinkProps = React.ComponentProps<typeof Link>;
 
 interface Crumbs extends LinkProps {
   label: string;
+  $closeDropdown?: () => void;
 }
 
 const BreadcrumbsWrapper = ({
@@ -32,9 +33,17 @@ const BreadcrumbsWrapper = ({
   const items = useMemo(() => {
     if (!data) return [];
 
-    const getLink = ({ label, href, ...props }: Crumbs, i: number) => (
-      <Link key={i} href={href} {...props} className={`${className}__link`}>
-        <span className="t-copy-sm t-truncate">{label}</span>
+    const getLink = ({ label, href, $closeDropdown }: Crumbs, i: number) => (
+      <Link
+        key={i}
+        href={href}
+        className={`${className}__link`}
+        legacyBehavior
+        passHref
+        onClick={$closeDropdown}
+      >
+        {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+        <a className="t-copy-sm t-truncate">{label}</a>
       </Link>
     );
 

--- a/packages/admin/components/atomic/MessageBlock/MessageBlock.styles.ts
+++ b/packages/admin/components/atomic/MessageBlock/MessageBlock.styles.ts
@@ -3,9 +3,9 @@ import { pxToRem } from "theme/mixins/functions";
 import MessageBlock from "./MessageBlock";
 type BaseProps = React.ComponentProps<typeof MessageBlock>;
 
-export const Wrapper = styled.div<Partial<BaseProps>>`
-  ${({ type }) =>
-    type === "error"
+export const Wrapper = styled.div<{ $type: BaseProps["type"] }>`
+  ${({ $type }) =>
+    $type === "error"
       ? css`
           --icon-background-color: var(--accent-color);
           --icon-foreground-color: var(--background-color);

--- a/packages/admin/components/atomic/MessageBlock/MessageBlock.tsx
+++ b/packages/admin/components/atomic/MessageBlock/MessageBlock.tsx
@@ -7,7 +7,7 @@ declare type Url = string | UrlObject;
 
 const MessageBlock = ({ type = "error", name, message, link }: Props) => {
   return (
-    <Styled.Wrapper type={type} className="a-bg-brand10 t-align-center">
+    <Styled.Wrapper $type={type} className="a-bg-brand10 t-align-center">
       <Styled.Inner>
         <IconFactory icon={type === "error" ? "warning" : "empty"} size="xlg" />
         <Styled.Header>{name}</Styled.Header>

--- a/packages/admin/components/atomic/Pagination/Pagination.styles.ts
+++ b/packages/admin/components/atomic/Pagination/Pagination.styles.ts
@@ -7,8 +7,8 @@ const Pagination = styled(PaginationWrapper)<Props>`
   --input-border-radius: ${pxToRem(6)};
   --input-text-align: center;
   --input-padding: 0 0 0 ${pxToRem(4)};
-  --pagination-input-width: ${({ totalPages }) =>
-    totalPages && pxToRem(totalPages.toString().length * 10 + 25)};
+  --pagination-input-width: ${({ $totalPages }) =>
+    $totalPages && pxToRem($totalPages.toString().length * 10 + 25)};
   display: flex;
   align-items: center;
   padding-block-start: ${pxToRem(24)};

--- a/packages/admin/components/atomic/Pagination/PaginationWrapper.tsx
+++ b/packages/admin/components/atomic/Pagination/PaginationWrapper.tsx
@@ -12,7 +12,7 @@ const PaginationWrapper = ({ className, ...props }: Props) => {
     submit: `a-hidden`,
     total: `${className}__total`,
   };
-  const { currentPage, totalPages } = props;
+  const { currentPage, $totalPages } = props;
 
   // Get current path and query without using next router
   const pathname = window.location.pathname;
@@ -24,7 +24,7 @@ const PaginationWrapper = ({ className, ...props }: Props) => {
     router.push({ pathname, query: { ...router.query, page: value } });
   };
 
-  if (!currentPage || !totalPages) return null;
+  if (!currentPage || !$totalPages) return null;
 
   return (
     <nav className={className} aria-label="Pagination Navigation">
@@ -58,7 +58,7 @@ const PaginationWrapper = ({ className, ...props }: Props) => {
           icon="arrow"
           iconRotate={90}
           aria-label="Next Page"
-          aria-disabled={currentPage >= totalPages}
+          aria-disabled={currentPage >= $totalPages}
         />
       </Link>
     </nav>
@@ -68,7 +68,7 @@ const PaginationWrapper = ({ className, ...props }: Props) => {
 interface Props {
   className?: string;
   currentPage?: Maybe<number> | number;
-  totalPages?: Maybe<number> | number;
+  $totalPages?: Maybe<number> | number;
 }
 
 export default PaginationWrapper;

--- a/packages/admin/components/atomic/buttons/Button/Button.styles.ts
+++ b/packages/admin/components/atomic/buttons/Button/Button.styles.ts
@@ -4,7 +4,7 @@ import { tLabel } from "theme/mixins/typography";
 import { aButton } from "theme/mixins/appearance";
 
 const Button = styled.button<Props>`
-  ${({ secondary }) => aButton(secondary)}
+  ${({ $secondary }) => aButton($secondary)}
 
   ${tLabel("lg")}
   border-radius: ${pxToRem(6)};
@@ -12,7 +12,7 @@ const Button = styled.button<Props>`
 `;
 
 interface Props extends React.HTMLProps<HTMLButtonElement> {
-  secondary?: boolean;
+  $secondary?: boolean;
 }
 
 export default Button;

--- a/packages/admin/components/atomic/buttons/ButtonControl/ButtonControl.styles.ts
+++ b/packages/admin/components/atomic/buttons/ButtonControl/ButtonControl.styles.ts
@@ -6,7 +6,10 @@ import BaseButtonControl from "./ButtonControl";
 
 type BaseProps = React.ComponentProps<typeof BaseButtonControl>;
 
-export const ButtonControl = styled.button<Pick<BaseProps, "size" | "icon">>`
+export const ButtonControl = styled.button<{
+  $size?: BaseProps["size"];
+  $icon?: BaseProps["icon"];
+}>`
   min-height: ${pxToRem(32)};
   display: inline-block;
   border: 1px solid transparent;
@@ -21,14 +24,14 @@ export const ButtonControl = styled.button<Pick<BaseProps, "size" | "icon">>`
   opacity: var(--button-control-opacity, 1);
   visibility: var(--button-control-visibility, visible);
 
-  ${({ size }) =>
-    size === "large" &&
+  ${({ $size }) =>
+    $size === "large" &&
     css`
       padding: ${pxToRem(12)};
     `}
 
-  ${({ icon }) =>
-    icon &&
+  ${({ $icon }) =>
+    $icon &&
     css`
       display: inline-flex;
       align-items: center;
@@ -67,18 +70,21 @@ export const ButtonControl = styled.button<Pick<BaseProps, "size" | "icon">>`
   }
 `;
 
-export const ButtonText = styled.span<Pick<BaseProps, "size" | "icon">>`
+export const ButtonText = styled.span<{
+  $size?: BaseProps["size"];
+  $icon?: BaseProps["icon"];
+}>`
   display: inline-block;
   white-space: nowrap;
 
-  ${({ size }) =>
-    size === "large" &&
+  ${({ $size }) =>
+    $size === "large" &&
     css`
       padding-inline-start: ${pxToRem(4)};
     `}
 
-  ${({ icon }) =>
-    icon &&
+  ${({ $icon }) =>
+    $icon &&
     css`
       padding-inline-end: ${pxToRem(10)};
     `}

--- a/packages/admin/components/atomic/buttons/ButtonControl/ButtonControl.tsx
+++ b/packages/admin/components/atomic/buttons/ButtonControl/ButtonControl.tsx
@@ -6,23 +6,40 @@ type IconFactoryProps = React.ComponentProps<typeof IconFactory>;
 type AuthorizeProps = React.ComponentProps<typeof Authorize>;
 
 const ButtonControl = forwardRef(
-  ({ children, iconRotate, actions, allowedActions, ...props }: Props, ref) => {
-    const { icon, size, closeDropdown, onClick } = props;
-
+  (
+    {
+      children,
+      iconRotate,
+      actions,
+      allowedActions,
+      $closeDropdown,
+      icon,
+      size,
+      onClick,
+      ...props
+    }: Props,
+    ref,
+  ) => {
     const handleClick = onClick
-      ? closeDropdown
+      ? $closeDropdown
         ? (e: React.MouseEvent) => {
-            closeDropdown();
+            $closeDropdown();
             onClick(e);
           }
         : onClick
-      : closeDropdown;
+      : $closeDropdown;
 
     const content = (
-      <Styled.ButtonControl ref={ref} onClick={handleClick} {...props}>
+      <Styled.ButtonControl
+        ref={ref}
+        onClick={handleClick}
+        $icon={icon}
+        $size={size}
+        {...props}
+      >
         <>
           {children && (
-            <Styled.ButtonText size={size} icon={icon}>
+            <Styled.ButtonText $size={size} $icon={icon}>
               {children}
             </Styled.ButtonText>
           )}
@@ -53,7 +70,7 @@ interface Props extends Omit<AuthorizeProps, "children"> {
   "aria-label"?: string;
   type?: "button" | "submit";
   size?: "large";
-  closeDropdown?: () => void;
+  $closeDropdown?: () => void;
 }
 
 export default ButtonControl;

--- a/packages/admin/components/atomic/buttons/ButtonControl/patterns/ButtonControlConfirm.tsx
+++ b/packages/admin/components/atomic/buttons/ButtonControl/patterns/ButtonControlConfirm.tsx
@@ -18,7 +18,7 @@ const ButtonControlConfirm = ({
   children,
   onClick: onConfirm,
   "aria-label": actionLabel,
-  closeDropdown,
+  $closeDropdown,
   actions,
   allowedActions,
 }: Props) => {
@@ -26,8 +26,8 @@ const ButtonControlConfirm = ({
 
   const handleClick = (e: React.MouseEvent) => {
     e.preventDefault();
-    if (closeDropdown) {
-      closeDropdown();
+    if ($closeDropdown) {
+      $closeDropdown();
     }
     dialog.show();
   };

--- a/packages/admin/components/atomic/buttons/ButtonControl/patterns/ButtonControlDrawer.tsx
+++ b/packages/admin/components/atomic/buttons/ButtonControl/patterns/ButtonControlDrawer.tsx
@@ -13,7 +13,7 @@ const ButtonControlDrawer = forwardRef(
       drawerQuery,
       icon,
       children,
-      closeDropdown,
+      $closeDropdown,
       ...buttonProps
     }: Props,
     ref,
@@ -24,7 +24,7 @@ const ButtonControlDrawer = forwardRef(
           as="a"
           icon={icon}
           ref={ref}
-          closeDropdown={closeDropdown}
+          $closeDropdown={$closeDropdown}
           {...buttonProps}
         >
           {children}

--- a/packages/admin/components/atomic/buttons/ButtonControlGroup/ButtonControlGroup.styles.ts
+++ b/packages/admin/components/atomic/buttons/ButtonControlGroup/ButtonControlGroup.styles.ts
@@ -5,7 +5,7 @@ import ButtonControlGroup from "./ButtonControlGroup";
 
 type BaseProps = React.ComponentProps<typeof ButtonControlGroup>;
 
-type WrapperProps = Pick<BaseProps, "breakpoint">;
+type WrapperProps = { $breakpoint: BaseProps["breakpoint"] };
 
 export const ButtonWrapper = styled.div<WrapperProps>`
   display: inline-flex;
@@ -17,25 +17,25 @@ export const ButtonWrapper = styled.div<WrapperProps>`
     }
   `)}
 
-  ${({ breakpoint }) =>
-    breakpoint &&
+  ${({ $breakpoint }) =>
+    $breakpoint &&
     respond(
       css`
         display: none;
       `,
-      breakpoint,
+      $breakpoint,
     )}
 `;
 
 export const DropdownWrapper = styled.div<WrapperProps>`
   display: none;
 
-  ${({ breakpoint }) =>
-    breakpoint &&
+  ${({ $breakpoint }) =>
+    $breakpoint &&
     respond(
       css`
         display: block;
       `,
-      breakpoint,
+      $breakpoint,
     )}
 `;

--- a/packages/admin/components/atomic/buttons/ButtonControlGroup/ButtonControlGroup.tsx
+++ b/packages/admin/components/atomic/buttons/ButtonControlGroup/ButtonControlGroup.tsx
@@ -20,10 +20,10 @@ function ButtonControlGroup({
 }: Props) {
   return (
     <>
-      <Styled.ButtonWrapper breakpoint={breakpoint}>
+      <Styled.ButtonWrapper $breakpoint={breakpoint}>
         {children}
       </Styled.ButtonWrapper>
-      <Styled.DropdownWrapper breakpoint={breakpoint}>
+      <Styled.DropdownWrapper $breakpoint={breakpoint}>
         <Dropdown
           label={menuLabel}
           disclosure={
@@ -44,7 +44,7 @@ interface BaseProps {
   menuLabel: string;
   toggleLabel?: string;
   toggleText?: string;
-  closeDropdown?: () => void;
+  $closeDropdown?: () => void;
   children: React.ReactElement<ButtonProps> | React.ReactElement<ButtonProps>[];
 }
 

--- a/packages/admin/components/atomic/dropdown/Dropdown/Dropdown.styles.ts
+++ b/packages/admin/components/atomic/dropdown/Dropdown/Dropdown.styles.ts
@@ -38,11 +38,11 @@ export const List = styled.ul<ListProps>`
     z-index: -1;
   }
 
-  ${({ right }) => right && `right: 0;`}
+  ${({ $right }) => $right && `right: 0;`}
 `;
 
 interface ListProps {
-  right?: boolean;
+  $right?: boolean;
 }
 
 export const Item = styled.li`

--- a/packages/admin/components/atomic/dropdown/Dropdown/Dropdown.tsx
+++ b/packages/admin/components/atomic/dropdown/Dropdown/Dropdown.tsx
@@ -29,7 +29,7 @@ const Dropdown = ({
   const submenu = (
     <Styled.List
       ref={elRef}
-      right={alignRight || out.right}
+      $right={alignRight || out.right}
       id={uid}
       aria-hidden={!active}
       hidden={!active}
@@ -38,7 +38,8 @@ const Dropdown = ({
         if (item === null) return null;
         return (
           <Styled.Item key={i}>
-            {item && React.cloneElement(item, { closeDropdown: closeDropdown })}
+            {item &&
+              React.cloneElement(item, { $closeDropdown: closeDropdown })}
           </Styled.Item>
         );
       })}

--- a/packages/admin/components/atomic/dropdown/DropdownMenu/DropdownMenu.styles.ts
+++ b/packages/admin/components/atomic/dropdown/DropdownMenu/DropdownMenu.styles.ts
@@ -13,8 +13,8 @@ export const MenuWrapper = styled(BaseMenu)`
 `;
 
 export const Menu = styled.div<StyledMenuProps>`
-  ${({ isMainNav }) =>
-    isMainNav
+  ${({ $isMainNav }) =>
+    $isMainNav
       ? css`
           --menu-align-items: flex-start;
           --menu-item-border: 2px solid transparent;
@@ -47,7 +47,7 @@ export const Menu = styled.div<StyledMenuProps>`
 `;
 
 interface StyledMenuProps {
-  isMainNav?: boolean;
+  $isMainNav?: boolean;
 }
 
 export const Item = styled(MenuItem)`

--- a/packages/admin/components/atomic/dropdown/DropdownMenu/DropdownMenu.tsx
+++ b/packages/admin/components/atomic/dropdown/DropdownMenu/DropdownMenu.tsx
@@ -14,7 +14,7 @@ const DropdownMenu = forwardRef<HTMLButtonElement, Props>(
           {(disclosureProps) => cloneElement(disclosure, disclosureProps)}
         </MenuButton>
         <Styled.MenuWrapper {...menu} {...menuProps} role="none">
-          <Styled.Menu isMainNav={isMainNav}>
+          <Styled.Menu $isMainNav={isMainNav}>
             {menuItems.map((item, i) => {
               if (item.type === MenuSeparator) {
                 return cloneElement(item, {

--- a/packages/admin/components/atomic/images/Avatar/Avatar.styles.ts
+++ b/packages/admin/components/atomic/images/Avatar/Avatar.styles.ts
@@ -2,30 +2,30 @@ import styled from "styled-components";
 import { aBgLight } from "theme/mixins/appearance";
 import { pxToRem } from "theme/mixins/functions";
 
-export const Wrapper = styled.div<{ size?: number }>`
+export const Wrapper = styled.div<{ $size?: number }>`
   border: 1px solid var(--accent-lighter);
   border-radius: 50%;
   background: var(--accent-color);
   overflow: hidden;
 
-  ${({ size }) =>
-    size &&
+  ${({ $size }) =>
+    $size &&
     `
-      width: ${pxToRem(size)};
-      height: ${pxToRem(size)};
+      width: ${pxToRem($size)};
+      height: ${pxToRem($size)};
     `}
 `;
 
-export const IconWrapper = styled.div<{ size?: number }>`
+export const IconWrapper = styled.div<{ $size?: number }>`
   ${aBgLight()}
   border-radius: 50%;
   overflow: hidden;
   color: var(--accent-color);
 
-  ${({ size }) =>
-    size &&
+  ${({ $size }) =>
+    $size &&
     `
-    width: ${pxToRem(size)};
-    height: ${pxToRem(size)};
+    width: ${pxToRem($size)};
+    height: ${pxToRem($size)};
   `}
 `;

--- a/packages/admin/components/atomic/images/Avatar/Avatar.tsx
+++ b/packages/admin/components/atomic/images/Avatar/Avatar.tsx
@@ -9,11 +9,11 @@ const Avatar = ({ data, size = 32, placeholder }: Props) => {
   const avatar = useMaybeFragment(fragment, data);
 
   return avatar?.storage ? (
-    <Styled.Wrapper size={size}>
+    <Styled.Wrapper $size={size}>
       <Image data={avatar?.small?.webp} width={size} height={size} />
     </Styled.Wrapper>
   ) : placeholder ? (
-    <Styled.IconWrapper size={size}>
+    <Styled.IconWrapper $size={size}>
       <IconFactory icon="avatar32" size="lg" />
     </Styled.IconWrapper>
   ) : null;

--- a/packages/admin/components/atomic/loading/LoadingCircle/LoadingCircle.tsx
+++ b/packages/admin/components/atomic/loading/LoadingCircle/LoadingCircle.tsx
@@ -9,7 +9,7 @@ const LoadingCircle = ({ label, className }: Props) => {
     <LoadingSkeleton
       role="progressbar"
       aria-label={t(label || "loading")}
-      noShimmer
+      $noShimmer
       className={className}
     >
       <LoadingCircleIcon />

--- a/packages/admin/components/atomic/loading/LoadingIcon/LoadingIcon.styles.ts
+++ b/packages/admin/components/atomic/loading/LoadingIcon/LoadingIcon.styles.ts
@@ -2,9 +2,9 @@ import styled from "styled-components";
 import { pxToRem } from "theme/mixins/functions";
 import { spin } from "theme/base/animations";
 
-const Circle = styled.div<{ size?: number }>`
-  height: ${({ size = 16 }) => pxToRem(size)};
-  width: ${({ size = 16 }) => pxToRem(size)};
+const Circle = styled.div<{ $size?: number }>`
+  height: ${({ $size = 16 }) => pxToRem($size)};
+  width: ${({ $size = 16 }) => pxToRem($size)};
   border-radius: 50%;
   border: 1px solid;
   border-top-color: var(--brand30);

--- a/packages/admin/components/atomic/loading/LoadingSkeleton/LoadingSkeleton.styles.tsx
+++ b/packages/admin/components/atomic/loading/LoadingSkeleton/LoadingSkeleton.styles.tsx
@@ -9,15 +9,15 @@ const LoadingSkeleton = styled.div<Props>`
   height: 100%;
   border-radius: var(--loading-border-radius);
   background: var(--brand10);
-  ${({ noShimmer }) =>
-    !noShimmer &&
+  ${({ $noShimmer }) =>
+    !$noShimmer &&
     css`
       animation: ${pulse} 2s infinite cubic-bezier(0.83, 0, 0.17, 1);
     `};
 `;
 
 interface Props {
-  noShimmer?: boolean;
+  $noShimmer?: boolean;
 }
 
 export default LoadingSkeleton;

--- a/packages/admin/components/atomic/navs/MobileSubNav/MobileSubNav.tsx
+++ b/packages/admin/components/atomic/navs/MobileSubNav/MobileSubNav.tsx
@@ -38,7 +38,9 @@ const MobileSubNav = ({ tabRoutes, sidebarLinks }: Props) => {
         ref={mobileNavRef}
       >
         <MobileMenuList>
-          {tabRoutes?.map(({ label = "", ...namedLinkProps }, i) => (
+          {/* Do not pass actions down to the DOM */}
+          {/* eslint-disable-next-line @typescript-eslint/no-unused-vars */}
+          {tabRoutes?.map(({ label = "", actions, ...namedLinkProps }, i) => (
             <li key={i}>
               <TabLink
                 active={RouteHelper.isRouteNameActive(namedLinkProps.route)}
@@ -53,6 +55,7 @@ const MobileSubNav = ({ tabRoutes, sidebarLinks }: Props) => {
           {sidebarLinks?.map(({ route, label = "", query }, i) => (
             <li key={i}>
               <NamedLink route={route} query={query} passHref>
+                {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                 <a
                   className="a-link"
                   aria-current={activeRoute?.name === route}
@@ -70,7 +73,9 @@ const MobileSubNav = ({ tabRoutes, sidebarLinks }: Props) => {
 
 interface Link extends NamedLinkProps {
   label?: string;
+  actions?: string[] | undefined;
 }
+
 interface Props {
   tabRoutes?: Link[];
   sidebarLinks?: Link[];

--- a/packages/admin/components/atomic/navs/MobileSubNav/MobileSubNav.tsx
+++ b/packages/admin/components/atomic/navs/MobileSubNav/MobileSubNav.tsx
@@ -39,7 +39,6 @@ const MobileSubNav = ({ tabRoutes, sidebarLinks }: Props) => {
       >
         <MobileMenuList>
           {/* Do not pass actions down to the DOM */}
-          {/* eslint-disable-next-line @typescript-eslint/no-unused-vars */}
           {tabRoutes?.map(({ label = "", actions, ...namedLinkProps }, i) => (
             <li key={i}>
               <TabLink

--- a/packages/admin/components/atomic/navs/SidebarNav/SidebarNav.styles.ts
+++ b/packages/admin/components/atomic/navs/SidebarNav/SidebarNav.styles.ts
@@ -16,7 +16,7 @@ export const ListItem = styled.li`
   }
 `;
 
-export const Link = styled.a<LinkProps>`
+export const Link = styled.a<{ $active: LinkProps["active"] }>`
   display: block;
   box-shadow: inset 0 -1px 0 var(--neutral40);
   padding-block-end: 6px;
@@ -28,8 +28,8 @@ export const Link = styled.a<LinkProps>`
   ${tHeading(3)}
 
   &:hover {
-    ${({ active }) =>
-      !active &&
+    ${({ $active }) =>
+      !$active &&
       css`
         color: inherit;
         box-shadow: inset 0 -1px 0 var(--color-base);
@@ -43,8 +43,8 @@ export const Link = styled.a<LinkProps>`
     ${aTextGlow("lightMode")}
   }
 
-  ${({ active }) =>
-    active &&
+  ${({ $active }) =>
+    $active &&
     css`
       box-shadow: inset 0 -2px 0 var(--accent-color);
       color: var(--accent-color);

--- a/packages/admin/components/atomic/navs/SidebarNav/SidebarNav.tsx
+++ b/packages/admin/components/atomic/navs/SidebarNav/SidebarNav.tsx
@@ -13,7 +13,7 @@ const SidebarNav = ({ links, className }: Props) => {
 
     return (
       <NamedLink route={route} query={query} passHref>
-        <Styled.Link active={active}>{t(label)}</Styled.Link>
+        <Styled.Link $active={active}>{t(label)}</Styled.Link>
       </NamedLink>
     );
   };

--- a/packages/admin/components/atomic/navs/TabNav/Tab/Tab.tsx
+++ b/packages/admin/components/atomic/navs/TabNav/Tab/Tab.tsx
@@ -34,7 +34,6 @@ interface Props {
   size?: "md" | "lg";
   bottomBorder?: boolean;
   as?: "a" | "button";
-  icon?: string;
 }
 
 export default forwardRef(Tab);

--- a/packages/admin/components/atomic/navs/TabNav/TabNav.tsx
+++ b/packages/admin/components/atomic/navs/TabNav/TabNav.tsx
@@ -17,7 +17,9 @@ const TabNav = ({ links }: Props) => {
   }
 
   // Check if we should render the tab as a dropdown or link
-  function renderTab({ label, route, ...props }: Link) {
+  // Do not pass actions down to the DOM
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  function renderTab({ label, route, actions, ...props }: Link) {
     const routeObj = RouteHelper.findRouteByName(route);
 
     const active = isActiveRoute(route);
@@ -28,7 +30,7 @@ const TabNav = ({ links }: Props) => {
         <Dropdown
           label={t(label || "")}
           disclosure={
-            <Tab as="button" active={active} icon="chevron">
+            <Tab as="button" active={active}>
               {t(label || "")}
             </Tab>
           }
@@ -65,9 +67,12 @@ const TabNav = ({ links }: Props) => {
     </Styled.Nav>
   ) : null;
 };
+
 interface Link extends NamedLinkProps {
   label?: string;
+  actions?: string[] | undefined;
 }
+
 interface Props {
   links?: Link[];
 }

--- a/packages/admin/components/composed/model/ModelPagination/ModelPagination.tsx
+++ b/packages/admin/components/composed/model/ModelPagination/ModelPagination.tsx
@@ -24,7 +24,7 @@ function ModelPagination<T extends ModelPaginationFragment$key>({
   return (
     <Pagination
       currentPage={enhancedData.pageInfo.page}
-      totalPages={enhancedData.pageInfo.pageCount}
+      $totalPages={enhancedData.pageInfo.pageCount}
     />
   );
 }

--- a/packages/admin/components/forms/AssetPropertySelect/AssetPropertySelect.tsx
+++ b/packages/admin/components/forms/AssetPropertySelect/AssetPropertySelect.tsx
@@ -72,7 +72,7 @@ const AssetPropertySelect = forwardRef(
             <DialogDisclosure
               as={ButtonControl}
               type="button"
-              icon="plus"
+              $icon="plus"
               {...dialog}
             >
               {t("forms.asset_property_select.add_file")}

--- a/packages/admin/components/forms/EntitySelector/EntitySelector.tsx
+++ b/packages/admin/components/forms/EntitySelector/EntitySelector.tsx
@@ -1,3 +1,5 @@
+import { forwardRef } from "react";
+import { MaybeRef } from "@castiron/common-types";
 import BaseInputWrapper from "../BaseInputWrapper";
 import Controller from "./EntitySelectorController";
 import * as Styled from "./EntitySelector.styles";
@@ -10,11 +12,11 @@ interface Props extends Omit<BaseProps, "children">, ControllerProps {
   isDisclosure?: boolean;
 }
 
-function EntitySelector({
-  height = "500px",
-  isDisclosure = false,
-  ...props
-}: Props) {
+function EntitySelector(
+  { height = "500px", isDisclosure = false, ...props }: Props,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  ref: MaybeRef<HTMLElement>,
+) {
   return isDisclosure ? (
     <Styled.DisclosureWrapper>
       <Styled.Wrapper $height={height}>
@@ -30,4 +32,4 @@ function EntitySelector({
   );
 }
 
-export default EntitySelector;
+export default forwardRef(EntitySelector);

--- a/packages/admin/components/forms/FileUpload/BaseFileUpload/BaseFileUpload.styles.ts
+++ b/packages/admin/components/forms/FileUpload/BaseFileUpload/BaseFileUpload.styles.ts
@@ -57,9 +57,9 @@ export const UploadText = styled.p`
   white-space: pre-wrap;
 `;
 
-export const UploadPreview = styled.div<
-  Pick<FileUploadPreviewProps, "isLoading">
->`
+export const UploadPreview = styled.div<{
+  $isLoading?: FileUploadPreviewProps["isLoading"];
+}>`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -69,7 +69,7 @@ export const UploadPreview = styled.div<
   padding: ${pxToRem(8)};
   transition: var(--opacity-transition);
 
-  ${({ isLoading }) => isLoading && `opacity: .7;`}
+  ${({ $isLoading }) => $isLoading && `opacity: .7;`}
 `;
 
 export const FileName = styled.span`

--- a/packages/admin/components/forms/FileUpload/BaseFileUpload/BaseFileUploadPreview.tsx
+++ b/packages/admin/components/forms/FileUpload/BaseFileUpload/BaseFileUploadPreview.tsx
@@ -20,7 +20,7 @@ const FileUploadPreview = ({ file, isLoading }: UploadStatusProps) => {
 
   // if no alt text is provided, image is considered presentation only.
   return file ? (
-    <Styled.UploadPreview isLoading={isLoading}>
+    <Styled.UploadPreview $isLoading={isLoading}>
       {fileImageUrl && isImage ? (
         <BaseImage
           image={{

--- a/packages/admin/components/forms/HiddenField/HiddenField.styles.ts
+++ b/packages/admin/components/forms/HiddenField/HiddenField.styles.ts
@@ -3,7 +3,7 @@ import styled from "styled-components";
 export const Wrapper = styled.div<WrapperProps>`
   flex-basis: var(--form-grid-item-width);
 
-  ${({ isWide }) => isWide && `flex-basis: var(--form-grid-item-width-wide);`}
+  ${({ $isWide }) => $isWide && `flex-basis: var(--form-grid-item-width-wide);`}
 
   &[aria-hidden="true"] {
     display: none;
@@ -11,5 +11,5 @@ export const Wrapper = styled.div<WrapperProps>`
 `;
 
 interface WrapperProps {
-  isWide?: boolean;
+  $isWide?: boolean;
 }

--- a/packages/admin/components/forms/HiddenField/HiddenField.tsx
+++ b/packages/admin/components/forms/HiddenField/HiddenField.tsx
@@ -11,7 +11,7 @@ function HiddenField<T extends FieldValues = FieldValues>({
   const watchValue = watch(field);
 
   return (
-    <Styled.Wrapper aria-hidden={watchValue !== showOn} isWide={isWide}>
+    <Styled.Wrapper aria-hidden={watchValue !== showOn} $isWide={isWide}>
       {children}
     </Styled.Wrapper>
   );

--- a/packages/admin/components/forms/ParentSelector/ParentSelectorModal.tsx
+++ b/packages/admin/components/forms/ParentSelector/ParentSelectorModal.tsx
@@ -54,6 +54,7 @@ export default function ParentSelectorModal({
         setValue("parentId", entity?.id ?? parentId);
         setSelected(entity);
       };
+
       return (
         <EntitySelector
           {...register("parentId", { required: true })}

--- a/packages/admin/components/global/Header/Header.styles.ts
+++ b/packages/admin/components/global/Header/Header.styles.ts
@@ -54,7 +54,7 @@ export const Item = styled.li`
   }
 `;
 
-export const AvatarLink = styled(NavLink)<{ active?: boolean }>`
+export const AvatarLink = styled(NavLink)<{ $active?: boolean }>`
   margin-block-start: ${pxToRem(5)};
   border-radius: 50%;
 

--- a/packages/admin/components/global/Header/HeaderAccount.tsx
+++ b/packages/admin/components/global/Header/HeaderAccount.tsx
@@ -57,7 +57,7 @@ const HeaderAccount = ({ accountNav }: Props) => {
       <Dropdown
         label={t(item.label)}
         disclosure={
-          <Styled.AvatarLink as="button" active={active}>
+          <Styled.AvatarLink as="button" $active={active}>
             <Avatar data={avatar} placeholder />
           </Styled.AvatarLink>
         }

--- a/packages/admin/components/layout/ConfirmModal/ConfirmModal.tsx
+++ b/packages/admin/components/layout/ConfirmModal/ConfirmModal.tsx
@@ -23,7 +23,7 @@ const ConfirmModal = ({
         <Styled.ConfirmButton onClick={onConfirm}>
           {actionLabel ?? i18next.t("common.confirm")}
         </Styled.ConfirmButton>
-        <Styled.ConfirmButton secondary onClick={handleClose}>
+        <Styled.ConfirmButton $secondary onClick={handleClose}>
           {i18next.t("common.cancel")}
         </Styled.ConfirmButton>
       </Styled.ButtonWrapper>

--- a/packages/admin/components/layout/ContentHeader/ContentHeader.styles.ts
+++ b/packages/admin/components/layout/ContentHeader/ContentHeader.styles.ts
@@ -7,7 +7,7 @@ type Props = React.ComponentProps<typeof ContentHeader>;
 
 const HEADER_WRAP_BREAK = 60;
 
-export const Wrapper = styled.div<Pick<Props, "headerStyle">>`
+export const Wrapper = styled.div<{ $headerStyle?: Props["headerStyle"] }>`
   border-bottom: 2px solid var(--accent-color);
   display: flex;
   justify-content: space-between;
@@ -22,10 +22,10 @@ export const Wrapper = styled.div<Pick<Props, "headerStyle">>`
     padding-block-start: ${pxToRem(40)};
   }
 
-  ${({ headerStyle = "primary" }) =>
-    headerStyle === "primary" &&
+  ${({ $headerStyle = "primary" }) =>
+    $headerStyle === "primary" &&
     css`
-      padding-block-end: ${pxToRem(headerStyle === "primary" ? 5 : 2)};
+      padding-block-end: ${pxToRem($headerStyle === "primary" ? 5 : 2)};
     `}
 
   ${noFlexGapSupport(`

--- a/packages/admin/components/layout/Grid/Grid.styles.ts
+++ b/packages/admin/components/layout/Grid/Grid.styles.ts
@@ -24,12 +24,14 @@ function tablet(content: CssContent) {
   `;
 }
 
-export const Wrapper = styled.div<Partial<Props>>`
+export const Wrapper = styled.div<{
+  $showCheckboxes?: Props["showCheckboxes"];
+}>`
   --checkbox-opacity: 0;
   border-top: 1px solid var(--border-color);
   contain: layout inline-size;
 
-  ${({ showCheckboxes }) => showCheckboxes && `--checkbox-opacity: 1;`}
+  ${({ $showCheckboxes }) => $showCheckboxes && `--checkbox-opacity: 1;`}
 
   ${tablet(
     `

--- a/packages/admin/components/layout/PageHeader/PageHeader.styles.ts
+++ b/packages/admin/components/layout/PageHeader/PageHeader.styles.ts
@@ -5,9 +5,9 @@ import PageHeader from "./PageHeader";
 
 type Props = React.ComponentProps<typeof PageHeader>;
 
-export const Header = styled.header<Pick<Props, "headerStyle">>`
-  ${({ headerStyle }) =>
-    headerStyle !== "secondary" &&
+export const Header = styled.header<{ $headerStyle: Props["headerStyle"] }>`
+  ${({ $headerStyle }) =>
+    $headerStyle !== "secondary" &&
     css`
       padding-block-start: ${pxToRem(24)};
     `}

--- a/packages/admin/components/layout/PageHeader/PageHeader.tsx
+++ b/packages/admin/components/layout/PageHeader/PageHeader.tsx
@@ -2,9 +2,9 @@ import isNil from "lodash/isNil";
 import {
   Breadcrumbs,
   NamedLink,
-  TabNav,
   SidebarNav,
   MobileSubNav,
+  TabNav,
 } from "components/atomic";
 import { ContentHeader } from "components/layout";
 import * as Styled from "./PageHeader.styles";
@@ -29,7 +29,7 @@ const PageHeader = ({
   return (
     <Styled.Header
       className={hideHeader ? "a-hidden" : ""}
-      headerStyle={headerStyle}
+      $headerStyle={headerStyle}
     >
       {!isNil(breadcrumbsProps) ? <Breadcrumbs {...breadcrumbsProps} /> : null}
       <ContentHeader

--- a/packages/admin/components/layout/Table/Table.styles.ts
+++ b/packages/admin/components/layout/Table/Table.styles.ts
@@ -12,14 +12,14 @@ export const TableWrapper = styled.div<TableWrapperProps>`
   --checkbox-opacity: 0;
   --checkbox-visibility: 0;
 
-  ${({ selectable }) =>
-    selectable &&
+  ${({ $selectable }) =>
+    $selectable &&
     css`
       --table-margin-left: ${pxToRem(52)};
     `}
 
-  ${({ showCheckboxes }) =>
-    showCheckboxes &&
+  ${({ $showCheckboxes }) =>
+    $showCheckboxes &&
     css`
       --checkbox-opacity: 1;
       --checkbox-visibility: 1;
@@ -29,8 +29,8 @@ export const TableWrapper = styled.div<TableWrapperProps>`
 `;
 
 interface TableWrapperProps {
-  selectable?: boolean;
-  showCheckboxes?: boolean;
+  $selectable?: boolean;
+  $showCheckboxes?: boolean;
 }
 
 export const Table = styled.table`

--- a/packages/admin/components/layout/Table/Table.tsx
+++ b/packages/admin/components/layout/Table/Table.tsx
@@ -19,8 +19,8 @@ const Table = ({
     <TableContext.Provider value={{ columnCount, setColumnCount }}>
       <Styled.TableWrapper
         id={id}
-        selectable={selectable}
-        showCheckboxes={showCheckboxes}
+        $selectable={selectable}
+        $showCheckboxes={showCheckboxes}
       >
         <Styled.Table aria-label={ariaLabel} role="grid" {...tableProps}>
           {children}

--- a/packages/admin/hooks/useChildRouteLinks.ts
+++ b/packages/admin/hooks/useChildRouteLinks.ts
@@ -8,6 +8,7 @@ import type { Props as NamedLinkProps } from "components/atomic/links/NamedLink/
 
 interface Link extends NamedLinkProps {
   label?: string;
+  actions?: string[] | undefined;
 }
 
 export function useChildRouteLinks(

--- a/packages/eslint/src/configs/config-ts.js
+++ b/packages/eslint/src/configs/config-ts.js
@@ -30,7 +30,13 @@ module.exports = {
     "no-console": ["error", { allow: ["warn", "error", "debug", "info"] }],
 
     // Typescript rules
-    "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+    "@typescript-eslint/no-unused-vars": [
+      "error", 
+      { 
+        argsIgnorePattern: "^_", 
+        ignoreRestSiblings: true,  
+      }
+    ],
     "@typescript-eslint/ban-ts-comment": [
       "error",
       { "ts-expect-error": "allow-with-description" },


### PR DESCRIPTION
After styled components was upgraded, styled-components started adding passed attributes to the DOM. The attributes need to be renamed with a leading `$` symbol. This change primarily helps developers - if the styled-component errors are removed, the more important errors are easier to parse.