### PR TITLE
[B] Show error block when PDF render fails

### DIFF
--- a/packages/frontend/components/composed/article/ArticleText/ArticleText.tsx
+++ b/packages/frontend/components/composed/article/ArticleText/ArticleText.tsx
@@ -7,7 +7,7 @@ import { convertToSlug } from "@wdp/lib/helpers";
 import dynamic from "next/dynamic";
 import { useTranslation } from "react-i18next";
 import { ContentImage, FullText } from "components/atomic";
-import { BackToTopBlock } from "components/layout";
+import { BackToTopBlock, NoContent } from "components/layout";
 import { ArticleTextFragment$key } from "@/relay/ArticleTextFragment.graphql";
 import * as Styled from "./ArticleText.styles";
 
@@ -84,7 +84,7 @@ export default function ArticleText({ data }: Props) {
       {pdf?.asset ? (
         <AssetInlinePDF data={pdf.asset} />
       ) : (
-        t("common.no_content")
+        <NoContent message={t("common.no_content")} />
       )}
     </Styled.BodyWrapper>
   );

--- a/packages/frontend/components/layout/messages/ErrorBlock/ErrorBlock.tsx
+++ b/packages/frontend/components/layout/messages/ErrorBlock/ErrorBlock.tsx
@@ -6,18 +6,20 @@ import { Button } from "@/components/atomic";
 import * as Styled from "./ErrorBlock.styles";
 
 interface Props {
+  /** Optional heading. Default is "A server error occured." */
+  heading?: string;
   /** The error message */
   message?: string;
   reset?: () => void;
 }
 
-export default function ErrorMessage({ message, reset }: Props) {
+export default function ErrorMessage({ heading, message, reset }: Props) {
   const { t } = useTranslation();
 
   return (
     <Styled.Wrapper>
-      <p className="t-h3">{t("messages.server_error")}</p>
-      <p className="a-color-light">{message}</p>
+      <p className="t-h3">{t("messages.server_error") || heading}</p>
+      <p className="a-color-light t-break-words">{message}</p>
       {reset && (
         <Button onClick={reset} size="sm">
           Try again

--- a/packages/frontend/lib/locales/en.json
+++ b/packages/frontend/lib/locales/en.json
@@ -147,7 +147,9 @@
       "document": "document",
       "file": "file",
       "view_full_pdf": "To view the rest of this document, please <downloadLink>download the PDF</downloadLink>.",
-      "pdf_cannot_be_displayed": "This PDF is over 100 MB and cannot be displayed. Please <downloadLink>download the PDF</downloadLink> instead."
+      "pdf_cannot_be_displayed": "This PDF is over 100 MB and cannot be displayed. Please <downloadLink>download the PDF</downloadLink> instead.",
+      "pdf_server_error": "Unexpected server response ({{code}}) while retrieving the PDF.",
+      "pdf_render_error": "Failed to load PDF file."
     },
     "metadata": {
       "author": "Author",
@@ -259,7 +261,8 @@
     },
     "messages": {
       "hidden": "This {{schema}} is hidden",
-      "server_error": "A server error occured."
+      "server_error": "A server error occured.",
+      "error": "An error occured."
     },
     "analytics": {
       "regions": {

--- a/packages/frontend/theme/utility/typography.ts
+++ b/packages/frontend/theme/utility/typography.ts
@@ -104,4 +104,8 @@ export default css`
   .t-align-center {
     text-align: center;
   }
+
+  .t-break-words {
+    word-break: break-word;
+  }
 `;


### PR DESCRIPTION
PDFs are occasionally failing to render on first load. On further investigation, I found that the downloadUrl generated on first load returns a 403 error (Forbidden). This change renders and logs an error when the PDF fails to load, which will help developers debug future issues.