### PR TITLE
[B] Catch infinite loop with former harvested records

### DIFF
--- a/packages/admin/components/composed/collection/CollectionLayout/CollectionLayout.tsx
+++ b/packages/admin/components/composed/collection/CollectionLayout/CollectionLayout.tsx
@@ -84,15 +84,16 @@ export default function CollectionLayout({
       >
         {t("common.view")}
       </ButtonControlView>
-      {memoizedCollection?.harvestModificationStatus !== "UNHARVESTED" && (
-        <ButtonControlRoute
-          route="harvestRecord"
-          query={{ slug: memoizedCollection?.harvestRecords?.[0].slug }}
-          icon="linkExternal"
-        >
-          {t("harvesting.view_entity_record")}
-        </ButtonControlRoute>
-      )}
+      {memoizedCollection?.harvestModificationStatus !== "UNHARVESTED" &&
+        memoizedCollection?.harvestRecords?.length && (
+          <ButtonControlRoute
+            route="harvestRecord"
+            query={{ slug: memoizedCollection?.harvestRecords?.[0]?.slug }}
+            icon="linkExternal"
+          >
+            {t("harvesting.view_entity_record")}
+          </ButtonControlRoute>
+        )}
       <ButtonControlConfirm
         modalLabel={t("messages.delete.confirm_label")}
         modalBody={t("messages.delete.confirm_body")}


### PR DESCRIPTION
When a record _has_ been harvested but no longer has associated harvest records, it won't be able to link back to its latest harvest record.

This was causing an infinite render loop when trying to render collections in just such a state.